### PR TITLE
fix: 카테고리 전환 이슈 해결

### DIFF
--- a/src/hooks/queries/prompts/usePromptQuery.tsx
+++ b/src/hooks/queries/prompts/usePromptQuery.tsx
@@ -20,7 +20,7 @@ const usePromptQuery = ({
     const itemsPerPage = 18;
 
     const { data, isLoading } = useQuery<GetPromptsResponse>({
-        queryKey: [currentPage, itemsPerPage, sortBy, limit, query],
+        queryKey: [currentPage, itemsPerPage, sortBy, limit, query, categories],
         queryFn: () =>
             getPrompts({
                 view_type: "open",


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   카테고리 전환 이슈 해결
    - queryKey에 카테고리 포함되어 있지 않아 발생
    
    + api Request에 category 바뀌는 부분 확인 가능 / 다만 백에서 같은 response 반환중