### PR TITLE
[홈] 프롬프트 리스트 조회시 categories에 단일 문자열 전달하도록 수정

### DIFF
--- a/src/apis/prompt/prompt.model.ts
+++ b/src/apis/prompt/prompt.model.ts
@@ -41,7 +41,7 @@ export type SortType = "created_at" | "star" | "usages" | "relevance";
 export type GetPromptsParams = {
     view_type: ViewType;
     query?: string;
-    categories?: string[];
+    categories?: string;
     sort_by?: SortType;
     sort_order?: "asc" | "desc";
     limit?: number;

--- a/src/hooks/queries/prompts/usePromptQuery.tsx
+++ b/src/hooks/queries/prompts/usePromptQuery.tsx
@@ -29,7 +29,8 @@ const usePromptQuery = ({
                 limit: limit ? limit : itemsPerPage,
                 sort_order: "desc",
                 query: query,
-                categories: categories,
+                ...(categories &&
+                    categories.length > 0 && { categories: categories[0] }),
             }).then((res) => res),
     });
 


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   프롬프트 리스트 조회시 categories에 단일 문자열 전달하도록 수정
    ex. `/prompts-list?...categories=writing`
