### PR TITLE
[프롬프트 수정] 수정 화면 구현 및 api 연결 2

### DIFF
--- a/src/apis/prompt/prompt.model.ts
+++ b/src/apis/prompt/prompt.model.ts
@@ -6,7 +6,7 @@ type PromptInputField = {
     default?: number;
 };
 
-type PromptDetails = {
+export type PromptDetails = {
     id: string;
     title: string;
     description: string;
@@ -29,7 +29,7 @@ type PaginationInfo = {
     is_last: boolean;
 };
 
-export type GetPromptsResponse = {
+export type GetPromptsListResponse = {
     prompt_info_list: PromptDetails[];
     page_meta_data: PaginationInfo;
 };
@@ -38,7 +38,7 @@ export type ViewType = "open" | "starred" | "my";
 
 export type SortType = "created_at" | "star" | "usages" | "relevance";
 
-export type GetPromptsParams = {
+export type GetPromptsListParams = {
     view_type: ViewType;
     query?: string;
     categories?: string[];

--- a/src/apis/prompt/prompt.model.ts
+++ b/src/apis/prompt/prompt.model.ts
@@ -41,7 +41,7 @@ export type SortType = "created_at" | "star" | "usages" | "relevance";
 export type GetPromptsListParams = {
     view_type: ViewType;
     query?: string;
-    categories?: string[];
+    categories?: string;
     sort_by?: SortType;
     sort_order?: "asc" | "desc";
     limit?: number;

--- a/src/apis/prompt/prompt.ts
+++ b/src/apis/prompt/prompt.ts
@@ -1,15 +1,16 @@
 import { AxiosError } from "axios";
 import { GET } from "../client";
 import {
-    GetPromptsResponse,
-    GetPromptsParams,
+    GetPromptsListResponse,
+    GetPromptsListParams,
+    PromptDetails,
 } from "@/apis/prompt/prompt.model";
 
-export const getPrompts = async (
-    params: GetPromptsParams
-): Promise<GetPromptsResponse> => {
+export const getPromptsList = async (
+    params: GetPromptsListParams
+): Promise<GetPromptsListResponse> => {
     try {
-        const res = await GET<GetPromptsResponse>("/prompts-list", {
+        const res = await GET<GetPromptsListResponse>("/prompts-list", {
             params,
         });
         return res.data.data;
@@ -17,6 +18,20 @@ export const getPrompts = async (
         if (error instanceof AxiosError) {
             console.error("Network error:", error.message);
             throw new Error("Failed to fetch prompts data");
+        } else {
+            throw error;
+        }
+    }
+};
+
+export const getPrompt = async (id: string): Promise<PromptDetails> => {
+    try {
+        const res = await GET<PromptDetails>(`/prompts/${id}`);
+        return res.data.data;
+    } catch (error) {
+        if (error instanceof AxiosError) {
+            console.error("Network error:", error.message);
+            throw new Error("Failed to fetch prompt data");
         } else {
             throw error;
         }

--- a/src/hooks/mutations/prompts/usePostPrompt.tsx
+++ b/src/hooks/mutations/prompts/usePostPrompt.tsx
@@ -35,7 +35,7 @@ export const createPrompt = async (prompt: CreatePromptRequest) => {
     return data;
 };
 
-interface PostPromptProps {
+export interface PostPromptProps {
     onSuccess: (res: BaseResponse<CreatePromptResponse>) => void;
     onError: (e: Error) => void;
 }

--- a/src/hooks/mutations/prompts/usePutPrompt.tsx
+++ b/src/hooks/mutations/prompts/usePutPrompt.tsx
@@ -1,0 +1,36 @@
+import { useMutation } from "@tanstack/react-query";
+import {
+    CreatePromptRequest,
+    CreatePromptResponse,
+    PostPromptProps,
+} from "./usePostPrompt";
+import { PUT } from "@/apis/client";
+
+/**
+ * 프롬프트 수정하기
+ */
+
+export const updatePrompt = async ({
+    prompt,
+    id,
+}: {
+    prompt: CreatePromptRequest;
+    id: string;
+}) => {
+    const { data } = await PUT<CreatePromptResponse>(`/prompts/${id}`, prompt);
+    return data;
+};
+
+export const usePutPrompt = ({ onSuccess, onError }: PostPromptProps) => {
+    return useMutation({
+        mutationFn: ({
+            prompt,
+            id,
+        }: {
+            prompt: CreatePromptRequest;
+            id: string;
+        }) => updatePrompt({ prompt, id }),
+        onSuccess,
+        onError,
+    });
+};

--- a/src/hooks/queries/QueryKeys.ts
+++ b/src/hooks/queries/QueryKeys.ts
@@ -1,17 +1,17 @@
 // [Reference] https://yogjin.tistory.com/121
 
-const LOCATION_KEYS = {
-    all: ["locations"] as const,
+const PROMPT_KEYS = {
+    all: ["prompts"] as const,
 
-    lists: () => [...LOCATION_KEYS.all, "list"] as const, // ["locations", "list"]
-    list: (filters: object) => [...LOCATION_KEYS.lists(), { filters }] as const, // ["locations", "list", "..."]
+    lists: () => [...PROMPT_KEYS.all, "list"] as const, // ["prompts", "list"]
+    list: (filters: object) => [...PROMPT_KEYS.lists(), { filters }] as const, // ["prompts", "list", "..."]
 
-    details: () => [...LOCATION_KEYS.all, "detail"] as const, // ["locations", "detail"]
-    detail: (id: string) => [...LOCATION_KEYS.details(), id] as const, // ["locations", "detail", "id"]
+    details: () => [...PROMPT_KEYS.all, "detail"] as const, // ["prompts", "detail"]
+    detail: (id: string) => [...PROMPT_KEYS.details(), id] as const, // ["prompts", "detail", "id"]
 };
 
 const PAYMENTS_KEYS = {
     all: ["payments"] as const,
 };
 
-export { LOCATION_KEYS, PAYMENTS_KEYS };
+export { PROMPT_KEYS, PAYMENTS_KEYS };

--- a/src/hooks/queries/prompts/usePromptQuery.tsx
+++ b/src/hooks/queries/prompts/usePromptQuery.tsx
@@ -1,54 +1,15 @@
+import { getPrompt } from "@/apis/prompt/prompt";
+import { PromptDetails } from "@/apis/prompt/prompt.model";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
-import { getPromptsList } from "@/apis/prompt/prompt";
-import { GetPromptsListResponse, SortType } from "@/apis/prompt/prompt.model";
 
-export interface PromptQueryProps {
-    sortBy: SortType;
-    limit?: number;
-    query?: string;
-    categories?: string[];
-}
-
-const usePromptQuery = ({
-    sortBy,
-    limit,
-    query,
-    categories,
-}: PromptQueryProps) => {
-    const [currentPage, setCurrentPage] = useState(1);
-    const itemsPerPage = 18;
-
-    const { data, isLoading } = useQuery<GetPromptsListResponse>({
-        queryKey: [currentPage, itemsPerPage, sortBy, limit, query],
-        queryFn: () =>
-            getPromptsList({
-                view_type: "open",
-                sort_by: sortBy,
-                page: currentPage,
-                limit: limit ? limit : itemsPerPage,
-                sort_order: "desc",
-                query: query,
-                categories: categories,
-            }).then((res) => res),
+const usePromptQuery = (id: string) => {
+    const { data, isLoading } = useQuery<PromptDetails>({
+        queryKey: [id],
+        queryFn: () => getPrompt(id).then((res) => res),
+        enabled: !!id,
     });
 
-    const handlePageChange = (page: number) => {
-        setCurrentPage(page);
-    };
-
-    useEffect(() => {
-        setCurrentPage(1);
-    }, [sortBy]);
-
-    return {
-        items: data?.prompt_info_list || [],
-        totalItems: data?.page_meta_data.total_count || 0,
-        isLoading,
-        currentPage,
-        itemsPerPage,
-        handlePageChange,
-    };
+    return { data, isLoading };
 };
 
 export default usePromptQuery;

--- a/src/hooks/queries/prompts/usePromptQuery.tsx
+++ b/src/hooks/queries/prompts/usePromptQuery.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { getPrompts } from "@/apis/prompt/prompt";
-import { GetPromptsResponse, SortType } from "@/apis/prompt/prompt.model";
+import { getPromptsList } from "@/apis/prompt/prompt";
+import { GetPromptsListResponse, SortType } from "@/apis/prompt/prompt.model";
 
 export interface PromptQueryProps {
     sortBy: SortType;
@@ -19,10 +19,10 @@ const usePromptQuery = ({
     const [currentPage, setCurrentPage] = useState(1);
     const itemsPerPage = 18;
 
-    const { data, isLoading } = useQuery<GetPromptsResponse>({
+    const { data, isLoading } = useQuery<GetPromptsListResponse>({
         queryKey: [currentPage, itemsPerPage, sortBy, limit, query],
         queryFn: () =>
-            getPrompts({
+            getPromptsList({
                 view_type: "open",
                 sort_by: sortBy,
                 page: currentPage,

--- a/src/hooks/queries/prompts/usePromptsListQuery.tsx
+++ b/src/hooks/queries/prompts/usePromptsListQuery.tsx
@@ -7,7 +7,7 @@ export interface PromptQueryProps {
     sortBy: SortType;
     limit?: number;
     query?: string;
-    categories?: string[];
+    categories?: string;
 }
 
 const usePromptsListQuery = ({
@@ -29,7 +29,7 @@ const usePromptsListQuery = ({
                 limit: limit ? limit : itemsPerPage,
                 sort_order: "desc",
                 query: query,
-                categories: categories,
+                ...(categories && { categories: categories[0] }),
             }).then((res) => res),
     });
 

--- a/src/hooks/queries/prompts/usePromptsListQuery.tsx
+++ b/src/hooks/queries/prompts/usePromptsListQuery.tsx
@@ -1,0 +1,54 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { getPromptsList } from "@/apis/prompt/prompt";
+import { GetPromptsListResponse, SortType } from "@/apis/prompt/prompt.model";
+
+export interface PromptQueryProps {
+    sortBy: SortType;
+    limit?: number;
+    query?: string;
+    categories?: string[];
+}
+
+const usePromptsListQuery = ({
+    sortBy,
+    limit,
+    query,
+    categories,
+}: PromptQueryProps) => {
+    const [currentPage, setCurrentPage] = useState(1);
+    const itemsPerPage = 18;
+
+    const { data, isLoading } = useQuery<GetPromptsListResponse>({
+        queryKey: [currentPage, itemsPerPage, sortBy, limit, query],
+        queryFn: () =>
+            getPromptsList({
+                view_type: "open",
+                sort_by: sortBy,
+                page: currentPage,
+                limit: limit ? limit : itemsPerPage,
+                sort_order: "desc",
+                query: query,
+                categories: categories,
+            }).then((res) => res),
+    });
+
+    const handlePageChange = (page: number) => {
+        setCurrentPage(page);
+    };
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [sortBy]);
+
+    return {
+        items: data?.prompt_info_list || [],
+        totalItems: data?.page_meta_data.total_count || 0,
+        isLoading,
+        currentPage,
+        itemsPerPage,
+        handlePageChange,
+    };
+};
+
+export default usePromptsListQuery;

--- a/src/hooks/queries/prompts/usePromptsListQuery.tsx
+++ b/src/hooks/queries/prompts/usePromptsListQuery.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { getPromptsList } from "@/apis/prompt/prompt";
 import { GetPromptsListResponse, SortType } from "@/apis/prompt/prompt.model";
+import { PROMPT_KEYS } from "@/hooks/queries/QueryKeys";
 
 export interface PromptQueryProps {
     sortBy: SortType;
@@ -19,8 +20,16 @@ const usePromptsListQuery = ({
     const [currentPage, setCurrentPage] = useState(1);
     const itemsPerPage = 18;
 
+    const queryKey = PROMPT_KEYS.list({
+        currentPage,
+        itemsPerPage,
+        sortBy,
+        limit,
+        query,
+        categories,
+    });
     const { data, isLoading } = useQuery<GetPromptsListResponse>({
-        queryKey: [currentPage, itemsPerPage, sortBy, limit, query],
+        queryKey: queryKey,
         queryFn: () =>
             getPromptsList({
                 view_type: "open",
@@ -29,7 +38,7 @@ const usePromptsListQuery = ({
                 limit: limit ? limit : itemsPerPage,
                 sort_order: "desc",
                 query: query,
-                ...(categories && { categories: categories[0] }),
+                categories: categories,
             }).then((res) => res),
     });
 

--- a/src/pages/home/components/Prompt/PaginatedPrompt.tsx
+++ b/src/pages/home/components/Prompt/PaginatedPrompt.tsx
@@ -42,7 +42,7 @@ const PaginatedPrompt = ({ type, usePage = true }: PaginatedPromptProps) => {
                 return {
                     sortBy: sortBy,
                     limit: undefined,
-                    categories: [searchCategory],
+                    categories: searchCategory,
                 };
         }
     })();

--- a/src/pages/home/components/Prompt/PaginatedPrompt.tsx
+++ b/src/pages/home/components/Prompt/PaginatedPrompt.tsx
@@ -1,9 +1,9 @@
 import { Pagination, Select } from "antd";
 import Prompt from "../Prompt/Prompt";
 import styled from "styled-components";
-import usePromptQuery, {
+import usePromptsListQuery, {
     PromptQueryProps,
-} from "@/hooks/queries/prompts/usePromptQuery";
+} from "@/hooks/queries/prompts/usePromptsListQuery";
 import { SortType } from "@/apis/prompt/prompt.model";
 import { useState } from "react";
 import { useRecoilValue } from "recoil";
@@ -54,7 +54,7 @@ const PaginatedPrompt = ({ type, usePage = true }: PaginatedPromptProps) => {
         itemsPerPage,
         handlePageChange,
         isLoading,
-    } = usePromptQuery({ ...promptQueryParams });
+    } = usePromptsListQuery({ ...promptQueryParams });
 
     const handleChange = (value: SortType) => {
         setSortBy(value);
@@ -108,6 +108,7 @@ const PaginatedPrompt = ({ type, usePage = true }: PaginatedPromptProps) => {
                               usages={item.usages}
                               colored={type === "popular"}
                               index={index + 1}
+                              id={item.id}
                           />
                       ))}
             </PromptWrapper>

--- a/src/pages/home/components/Prompt/PaginatedPrompt.tsx
+++ b/src/pages/home/components/Prompt/PaginatedPrompt.tsx
@@ -108,7 +108,6 @@ const PaginatedPrompt = ({ type, usePage = true }: PaginatedPromptProps) => {
                               usages={item.usages}
                               colored={type === "popular"}
                               index={index + 1}
-                              id={item.id}
                           />
                       ))}
             </PromptWrapper>

--- a/src/pages/promptNew/components/FormSection.tsx
+++ b/src/pages/promptNew/components/FormSection.tsx
@@ -24,8 +24,9 @@ const AI = Object.entries(AIPlatforms).map(([key, value]) => ({
 
 interface FormSectionProps {
     onSumbit: () => void;
+    isEdit: boolean;
 }
-function FormSection({ onSumbit }: FormSectionProps) {
+function FormSection({ onSumbit, isEdit }: FormSectionProps) {
     const {
         control,
         formState: { isValid },
@@ -181,7 +182,7 @@ function FormSection({ onSumbit }: FormSectionProps) {
                 onClick={onSumbit}
                 hierarchy={isValid ? "primary" : "disabled"}
             >
-                프롬프트 등록 완료하기
+                {isEdit ? "프롬프트 수정 완료하기" : "프롬프트 등록 완료하기"}
             </Button>
         </Box>
     );

--- a/src/pages/promptNew/index.tsx
+++ b/src/pages/promptNew/index.tsx
@@ -20,7 +20,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Flex } from "antd";
 import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 import { z } from "zod";
 
@@ -33,6 +33,10 @@ export default function PromptNewPage({ isEdit = false }: PromptNewPageProps) {
     const { promptId } = useParams<{ promptId: string }>();
     const { data } = usePromptQuery(promptId ?? "");
 
+    const navigate = useNavigate();
+
+    const mode = !isEdit ? "등록" : "수정";
+
     const form = useForm<PromptSchemaType>({
         resolver: zodResolver(promptSchema),
         defaultValues: defaultPromptSchema,
@@ -42,6 +46,8 @@ export default function PromptNewPage({ isEdit = false }: PromptNewPageProps) {
         onSuccess(res) {
             console.log("Success", res);
             alert(res.detail || "프롬프트를 등록하였습니다.");
+
+            navigate(`/prompt-edit/${res.data.prompt_id}`, { replace: true });
         },
         onError(e) {
             console.error("Failed", e);
@@ -119,11 +125,11 @@ export default function PromptNewPage({ isEdit = false }: PromptNewPageProps) {
             <Container>
                 <PromptNewWrapper>
                     <Text font="large_32_bold" style={{ marginTop: "40px" }}>
-                        나만의 프롬프트 등록하기
+                        나만의 프롬프트 {mode}하기
                     </Text>
 
                     <Text font="h2_20_reg" color="G_400">
-                        실시간으로 미리보기 화면을 보면서 등록하는 나만의
+                        실시간으로 미리보기 화면을 보면서 {mode}하는 나만의
                         프롬프트
                     </Text>
 

--- a/src/pages/promptNew/index.tsx
+++ b/src/pages/promptNew/index.tsx
@@ -5,6 +5,7 @@ import {
     InputFormat,
     usePostPrompt,
 } from "@/hooks/mutations/prompts/usePostPrompt";
+import { usePutPrompt } from "@/hooks/mutations/prompts/usePutPrompt";
 import usePromptQuery from "@/hooks/queries/prompts/usePromptQuery";
 import { Wrapper } from "@/layouts/Layout";
 import FormSection from "@/pages/promptNew/components/FormSection";
@@ -37,7 +38,7 @@ export default function PromptNewPage({ isEdit = false }: PromptNewPageProps) {
         defaultValues: defaultPromptSchema,
     });
 
-    const { mutate } = usePostPrompt({
+    const { mutate: createPromptMutate } = usePostPrompt({
         onSuccess(res) {
             console.log("Success", res);
             alert(res.detail || "프롬프트를 등록하였습니다.");
@@ -46,6 +47,17 @@ export default function PromptNewPage({ isEdit = false }: PromptNewPageProps) {
         onError(e) {
             console.error("Failed", e);
             alert("프롬프트 등록에 실패하였습니다.");
+        },
+    });
+
+    const { mutate: updatePromptMutate } = usePutPrompt({
+        onSuccess(res) {
+            console.log("Success", res);
+            alert(res.detail || "프롬프트가 수정되었습니다.");
+        },
+        onError(e) {
+            console.error("Failed", e);
+            alert("프롬프트 수정에 실패하였습니다.");
         },
     });
 
@@ -70,7 +82,14 @@ export default function PromptNewPage({ isEdit = false }: PromptNewPageProps) {
                 };
 
                 console.log(">> promptData", promptData);
-                mutate(promptData);
+
+                if (isEdit && promptId) {
+                    // 수정 모드일 때 updatePrompt 호출
+                    updatePromptMutate({ prompt: promptData, id: promptId });
+                } else {
+                    // 생성 모드일 때 createPrompt 호출
+                    createPromptMutate(promptData);
+                }
             },
             (errors) => {
                 console.error(">> error", errors);

--- a/src/pages/promptNew/index.tsx
+++ b/src/pages/promptNew/index.tsx
@@ -42,7 +42,6 @@ export default function PromptNewPage({ isEdit = false }: PromptNewPageProps) {
         onSuccess(res) {
             console.log("Success", res);
             alert(res.detail || "프롬프트를 등록하였습니다.");
-            form.reset(defaultPromptSchema);
         },
         onError(e) {
             console.error("Failed", e);
@@ -78,6 +77,7 @@ export default function PromptNewPage({ isEdit = false }: PromptNewPageProps) {
 
                 const promptData: CreatePromptRequest = {
                     ...input,
+                    visibility: input.visibility.toLowerCase(),
                     user_input_format: user_input_formats,
                 };
 
@@ -90,6 +90,7 @@ export default function PromptNewPage({ isEdit = false }: PromptNewPageProps) {
                     // 생성 모드일 때 createPrompt 호출
                     createPromptMutate(promptData);
                 }
+                form.reset(defaultPromptSchema);
             },
             (errors) => {
                 console.error(">> error", errors);

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -43,10 +43,10 @@ const router = createBrowserRouter([
                 ),
             },
             {
-                path: "/prompt-edit",
+                path: "/prompt-edit/:promptId",
                 element: (
                     <ProtectedRoute>
-                        <PromptNewPage />
+                        <PromptNewPage isEdit={true} />
                     </ProtectedRoute>
                 ),
             },

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -43,6 +43,14 @@ const router = createBrowserRouter([
                 ),
             },
             {
+                path: "/prompt-edit",
+                element: (
+                    <ProtectedRoute>
+                        <PromptNewPage />
+                    </ProtectedRoute>
+                ),
+            },
+            {
                 path: "/my",
                 element: (
                     <ProtectedRoute>


### PR DESCRIPTION
[해당 PR ](https://github.com/ai-surfers/pocket-prompt-frontend/pull/36)정상적으로 머지되지 않아 다시 PR 올립니다

## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

- 프롬프트 상세 조회 api 및 usePromptQuery 구현

- PromptNew 컴포넌트에서 수정 모드 구현
    - 수정 모드일 경우 상세 조회 데이터로 초기 값 덮어씌움
    - 수정 모드일 경우 수정 api 사용하도록 변경

- 프롬프트 생성시 visibility 소문자로 처리하도록 변경
    - 이부분 토글 컴포넌트 수정이 필요해 보이는데, 시간이 부족해서 일단 api request시 소문자로 변경해서 넘겨주고 response 받은 부분은 대문자로 바꿔주도록 임시 처리했습니다 ㅠㅠ

## 📸 Screenshot

- 익스텐션 연결 이후 첨부 예정

