### PR TITLE
[기타] API 헤더에 source-location 추가

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -22,6 +22,8 @@ API.interceptors.request.use(
             config.headers.Authorization = `Bearer ${accessToken}`;
         }
 
+        config.headers["source-location"] = "web";
+
         console.log(`${config.url} -- ✈ `, config.data || "");
         return config;
     },


### PR DESCRIPTION
## 🏆 Details
- web/extension 로깅 구분을 위한 목적으로 헤더에 `source-location: web`을 추가했습니다
- 전체 요청 시에 헤더에 보내기로 이야기되어서 여기에 추가했어요
<img width="592" alt="image" src="https://github.com/user-attachments/assets/ca5b09af-d298-443f-ab61-852ee7e33451">
