### PR TITLE
[사이드바] 모바일 헤더 사이드바구현 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "homepage": "https://ai-surfers.github.io/resp",
     "scripts": {
-        "dev": "vite",
+        "dev": "vite --host",
         "prod": "vite --mode production",
         "build": "tsc -b && vite build",
         "build:dev": "tsc -b && vite build --mode development",

--- a/src/assets/svg/home/Close.tsx
+++ b/src/assets/svg/home/Close.tsx
@@ -1,5 +1,5 @@
 import type { SVGProps } from "react";
-const Close = (props: SVGProps<SVGSVGElement>) => (
+const Close = ({ stroke = "white", ...props }: SVGProps<SVGSVGElement>) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"
@@ -10,7 +10,7 @@ const Close = (props: SVGProps<SVGSVGElement>) => (
     >
         <path
             d="M18 18L12 12M12 12L6 6M12 12L18 6M12 12L6 18"
-            stroke="white"
+            stroke={stroke}
             stroke-width="1.5"
             stroke-linecap="round"
             stroke-linejoin="round"

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -15,7 +15,10 @@ import { useMediaQuery } from "react-responsive";
 import { MenuOutlined } from "@ant-design/icons";
 import { Menus } from "@/core/Menu";
 
-export default function Header({ onOpen }) {
+type HeaderProps = {
+    onOpen: () => void;
+};
+export default function Header({ onOpen }: HeaderProps) {
     const { setUser, resetUserState, userData } = useUser();
 
     const isUnderTablet = useMediaQuery({

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -14,7 +14,7 @@ import {
 import { useMediaQuery } from "react-responsive";
 import { MenuOutlined } from "@ant-design/icons";
 
-export default function Header() {
+export default function Header({ onOpen }) {
     const { setUser, resetUserState, userData } = useUser();
 
     const isUnderTablet = useMediaQuery({
@@ -62,7 +62,7 @@ export default function Header() {
 
                 <HeaderRightContainer>
                     {isUnderTablet ? (
-                        <MenuOutlined />
+                        <MenuOutlined onClick={onOpen} />
                     ) : userData.isLogin ? (
                         <User />
                     ) : (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/utils/storageUtils";
 import { useMediaQuery } from "react-responsive";
 import { MenuOutlined } from "@ant-design/icons";
+import { Menus } from "@/core/Menu";
 
 export default function Header({ onOpen }) {
     const { setUser, resetUserState, userData } = useUser();
@@ -51,11 +52,11 @@ export default function Header({ onOpen }) {
                     </StyledNavLink>
                     {!isUnderTablet && (
                         <TabBarContainer>
-                            <StyledNavLink to="/">Home</StyledNavLink>
-                            <StyledNavLink to="/extension">
-                                Extension
-                            </StyledNavLink>
-                            <StyledNavLink to="/price">Pricing</StyledNavLink>
+                            {Menus.map((menu, idx) => (
+                                <StyledNavLink to={menu.path} key={idx}>
+                                    {menu.label}
+                                </StyledNavLink>
+                            ))}
                         </TabBarContainer>
                     )}
                 </HeaderLeftContainer>

--- a/src/components/Header/LoginButton/LoginButton.tsx
+++ b/src/components/Header/LoginButton/LoginButton.tsx
@@ -1,5 +1,6 @@
 import { getUser, login } from "@/apis/auth/auth";
 import { auth, PROVIDER } from "@/apis/firebase";
+import Text from "@/components/common/Text/Text";
 import { useUser } from "@/hooks/useUser";
 import {
     LOCALSTORAGE_KEYS,
@@ -52,17 +53,21 @@ export default function LoginButton() {
         setUser(userData);
     }
 
-    return <Button onClick={handleLogin}>로그인</Button>;
+    return (
+        <Button onClick={handleLogin}>
+            <Text font="b2_16_semi" color="white">
+                로그인
+            </Text>
+        </Button>
+    );
 }
 
 const Button = styled.div`
     border-radius: 12px;
     padding: 10px 12px;
 
-    ${({ theme }) => theme.fonts.body3};
-    ${({ theme }) => theme.fonts.semibold};
     background: ${({ theme }) => theme.colors.primary};
-    color: ${({ theme }) => theme.colors.white};
+    ${({ theme }) => theme.mixins.flexBox()}
 
     cursor: pointer;
 `;

--- a/src/components/Sidebar/Item/GuideItem.tsx
+++ b/src/components/Sidebar/Item/GuideItem.tsx
@@ -1,0 +1,35 @@
+import Text from "@/components/common/Text/Text";
+import Icon from "@/pages/home/components/common/Icon";
+import { Flex } from "antd";
+import styled from "styled-components";
+
+const GuideItem = () => {
+    const handleOnGuide = () => {
+        window.open(
+            "https://pocket-prompt.notion.site/da477857a0cc44888b06dd23cf6682ff",
+            "_blank"
+        );
+    };
+    return (
+        <Item onClick={handleOnGuide}>
+            <Flex justify="space-between">
+                <Flex gap={8}>
+                    <Icon name="Book" />
+                    <Text font="b2_16_reg" color="primary">
+                        Guide
+                    </Text>
+                </Flex>
+                <Icon name="ExportSquare" />
+            </Flex>
+        </Item>
+    );
+};
+
+const Item = styled.div`
+    width: 100%;
+    padding: 14px 20px;
+    position: relative;
+    cursor: pointer;
+`;
+
+export default GuideItem;

--- a/src/components/Sidebar/Item/MenuItem.tsx
+++ b/src/components/Sidebar/Item/MenuItem.tsx
@@ -1,0 +1,51 @@
+import Text from "@/components/common/Text/Text";
+import { useLocation, useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+type MenuItemProps = {
+    menu: {
+        label: string;
+        path: string;
+    };
+    onClose: () => void;
+};
+const MenuItem = ({ menu, onClose }: MenuItemProps) => {
+    const location = useLocation();
+    const selected = location.pathname === menu.path;
+
+    const font = selected ? "b2_16_med" : "b2_16_reg";
+    const color = selected ? "primary" : "G_400";
+
+    const navigate = useNavigate();
+    const handleOnNavigate = () => {
+        navigate(menu.path);
+        onClose();
+    };
+    return (
+        <Item onClick={handleOnNavigate}>
+            {selected && <Rectangle />}
+            <Text font={font} color={color}>
+                {menu.label}
+            </Text>
+        </Item>
+    );
+};
+
+const Item = styled.div`
+    width: 100%;
+    padding: 14px 20px;
+    position: relative;
+    cursor: pointer;
+`;
+
+const Rectangle = styled.div`
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 4px;
+    height: 100%;
+    border-radius: 0px 2px 2px 0px;
+    background: ${({ theme }) => theme.colors.primary};
+`;
+
+export default MenuItem;

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,15 +1,18 @@
 import { Logo } from "@/assets/svg";
 import Close from "@/assets/svg/home/Close";
-import Text from "@/components/common/Text/Text";
 import LoginButton from "@/components/Header/LoginButton/LoginButton";
+import GuideItem from "@/components/Sidebar/Item/GuideItem";
+import MenuItem from "@/components/Sidebar/Item/MenuItem";
 import { Menus } from "@/core/Menu";
 import { useUser } from "@/hooks/useUser";
-import Icon from "@/pages/home/components/common/Icon";
-import { Drawer, Flex } from "antd";
-import { useLocation, useNavigate } from "react-router-dom";
+import { Drawer } from "antd";
 import styled from "styled-components";
 
-export default function Sidebar({ open, onClose }) {
+type SidebarProps = {
+    open: boolean;
+    onClose: () => void;
+};
+export default function Sidebar({ open, onClose }: SidebarProps) {
     const { userData } = useUser();
 
     return (
@@ -72,70 +75,3 @@ const BodyContainer = styled.div`
     height: 100%;
     padding: 12px 0;
 `;
-
-type MenuItemProps = {
-    menu: {
-        label: string;
-        path: string;
-    };
-    onClose: () => void;
-};
-const MenuItem = ({ menu, onClose }: MenuItemProps) => {
-    const location = useLocation();
-    const selected = location.pathname === menu.path;
-
-    const font = selected ? "b2_16_med" : "b2_16_reg";
-    const color = selected ? "primary" : "G_400";
-
-    const navigate = useNavigate();
-    const handleOnNavigate = () => {
-        navigate(menu.path);
-        onClose();
-    };
-    return (
-        <Item onClick={handleOnNavigate}>
-            {selected && <Rectangle />}
-            <Text font={font} color={color}>
-                {menu.label}
-            </Text>
-        </Item>
-    );
-};
-const Item = styled.div`
-    width: 100%;
-    padding: 14px 20px;
-    position: relative;
-    cursor: pointer;
-`;
-
-const Rectangle = styled.div`
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 4px;
-    height: 100%;
-    border-radius: 0px 2px 2px 0px;
-    background: ${({ theme }) => theme.colors.primary};
-`;
-
-const GuideItem = () => {
-    const handleOnGuide = () => {
-        window.open(
-            "https://pocket-prompt.notion.site/da477857a0cc44888b06dd23cf6682ff",
-            "_blank"
-        );
-    };
-    return (
-        <Item onClick={handleOnGuide}>
-            <Flex justify="space-between">
-                <Flex gap={8}>
-                    <Icon name="Book" />
-                    <Text font="b2_16_reg" color="primary">
-                        Guide
-                    </Text>
-                </Flex>
-                <Icon name="ExportSquare" />
-            </Flex>
-        </Item>
-    );
-};

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,0 +1,136 @@
+import { Logo } from "@/assets/svg";
+import Close from "@/assets/svg/home/Close";
+import Text from "@/components/common/Text/Text";
+import LoginButton from "@/components/Header/LoginButton/LoginButton";
+import Icon from "@/pages/home/components/common/Icon";
+import { Drawer, Flex } from "antd";
+import { useLocation } from "react-router-dom";
+import styled from "styled-components";
+
+const Menus = [
+    {
+        label: "Home",
+        path: "/",
+    },
+    {
+        label: "Extension",
+        path: "/extension",
+    },
+    {
+        label: "Pricing",
+        path: "/price",
+    },
+];
+export default function Sidebar() {
+    return (
+        <StyledDrawer
+            id="drawer"
+            className="drawer"
+            width="100%"
+            open={true}
+            closable={false}
+            style={{ background: "none" }}
+        >
+            <HeaderContainer>
+                <Logo style={{ width: "44px" }} />
+                <Close stroke="#3E4151" />
+            </HeaderContainer>
+
+            <BodyContainer>
+                <div style={{ margin: "0 20px 12px" }}>
+                    <LoginButton />
+                </div>
+
+                {Menus.map((menu, idx) => (
+                    <MenuItem menu={menu} key={idx} />
+                ))}
+                <GuideItem />
+            </BodyContainer>
+        </StyledDrawer>
+    );
+}
+
+const StyledDrawer = styled(Drawer)`
+    .ant-drawer-body {
+        padding: 0;
+        background: rgba(255, 255, 255, 0.9);
+        backdrop-filter: blur(40px);
+    }
+`;
+
+const HeaderContainer = styled.header`
+    width: 100%;
+
+    height: 52px;
+    padding: 4px 20px;
+
+    background: rgba(255, 255, 255, 0.6);
+    backdrop-filter: blur(40px);
+    box-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.02);
+
+    position: sticky;
+    top: 0;
+    left: 0;
+
+    ${({ theme }) => theme.mixins.flexBox("row", "space-between")};
+`;
+
+const BodyContainer = styled.div`
+    width: 100%;
+    height: 100%;
+    padding: 24px 0;
+`;
+
+type MenuItemProps = {
+    menu: {
+        label: string;
+        path: string;
+    };
+};
+const MenuItem = ({ menu }: MenuItemProps) => {
+    const location = useLocation();
+    const selected = location.pathname === menu.path;
+    const font = selected ? "b2_16_med" : "b2_16_reg";
+    const color = selected ? "primary" : "G_400";
+
+    return (
+        <Item>
+            {selected && <Rectangle />}
+            <Text font={font} color={color}>
+                {menu.label}
+            </Text>
+        </Item>
+    );
+};
+const Item = styled.div`
+    width: 100%;
+    padding: 14px 20px;
+    position: relative;
+    cursor: pointer;
+`;
+
+const Rectangle = styled.div`
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 4px;
+    height: 100%;
+    border-radius: 0px 2px 2px 0px;
+    background: ${({ theme }) => theme.colors.primary};
+`;
+
+const GuideItem = () => {
+    return (
+        <Item>
+            <Flex justify="space-between">
+                <Flex gap={8}>
+                    <Icon name="Book" />
+                    <Text font="b2_16_reg" color="primary">
+                        Guide
+                    </Text>
+                </Flex>
+                <Icon name="ExportSquare" />
+            </Flex>
+        </Item>
+    );
+};

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@ import { Logo } from "@/assets/svg";
 import Close from "@/assets/svg/home/Close";
 import Text from "@/components/common/Text/Text";
 import LoginButton from "@/components/Header/LoginButton/LoginButton";
+import { useUser } from "@/hooks/useUser";
 import Icon from "@/pages/home/components/common/Icon";
 import { Drawer, Flex } from "antd";
 import { useLocation } from "react-router-dom";
@@ -21,25 +22,29 @@ const Menus = [
         path: "/price",
     },
 ];
-export default function Sidebar() {
+export default function Sidebar({ open, onClose }) {
+    const { userData } = useUser();
+
     return (
         <StyledDrawer
             id="drawer"
             className="drawer"
             width="100%"
-            open={true}
+            open={open}
             closable={false}
             style={{ background: "none" }}
         >
             <HeaderContainer>
                 <Logo style={{ width: "44px" }} />
-                <Close stroke="#3E4151" />
+                <Close stroke="#3E4151" onClick={onClose} />
             </HeaderContainer>
 
             <BodyContainer>
-                <div style={{ margin: "0 20px 12px" }}>
-                    <LoginButton />
-                </div>
+                {!userData.isLogin && (
+                    <div style={{ margin: "12px 20px" }}>
+                        <LoginButton />
+                    </div>
+                )}
 
                 {Menus.map((menu, idx) => (
                     <MenuItem menu={menu} key={idx} />
@@ -78,7 +83,7 @@ const HeaderContainer = styled.header`
 const BodyContainer = styled.div`
     width: 100%;
     height: 100%;
-    padding: 24px 0;
+    padding: 12px 0;
 `;
 
 type MenuItemProps = {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -2,26 +2,13 @@ import { Logo } from "@/assets/svg";
 import Close from "@/assets/svg/home/Close";
 import Text from "@/components/common/Text/Text";
 import LoginButton from "@/components/Header/LoginButton/LoginButton";
+import { Menus } from "@/core/Menu";
 import { useUser } from "@/hooks/useUser";
 import Icon from "@/pages/home/components/common/Icon";
 import { Drawer, Flex } from "antd";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
-const Menus = [
-    {
-        label: "Home",
-        path: "/",
-    },
-    {
-        label: "Extension",
-        path: "/extension",
-    },
-    {
-        label: "Pricing",
-        path: "/price",
-    },
-];
 export default function Sidebar({ open, onClose }) {
     const { userData } = useUser();
 
@@ -47,7 +34,7 @@ export default function Sidebar({ open, onClose }) {
                 )}
 
                 {Menus.map((menu, idx) => (
-                    <MenuItem menu={menu} key={idx} />
+                    <MenuItem menu={menu} key={idx} onClose={onClose} />
                 ))}
                 <GuideItem />
             </BodyContainer>
@@ -91,15 +78,22 @@ type MenuItemProps = {
         label: string;
         path: string;
     };
+    onClose: () => void;
 };
-const MenuItem = ({ menu }: MenuItemProps) => {
+const MenuItem = ({ menu, onClose }: MenuItemProps) => {
     const location = useLocation();
     const selected = location.pathname === menu.path;
+
     const font = selected ? "b2_16_med" : "b2_16_reg";
     const color = selected ? "primary" : "G_400";
 
+    const navigate = useNavigate();
+    const handleOnNavigate = () => {
+        navigate(menu.path);
+        onClose();
+    };
     return (
-        <Item>
+        <Item onClick={handleOnNavigate}>
             {selected && <Rectangle />}
             <Text font={font} color={color}>
                 {menu.label}
@@ -125,8 +119,14 @@ const Rectangle = styled.div`
 `;
 
 const GuideItem = () => {
+    const handleOnGuide = () => {
+        window.open(
+            "https://pocket-prompt.notion.site/da477857a0cc44888b06dd23cf6682ff",
+            "_blank"
+        );
+    };
     return (
-        <Item>
+        <Item onClick={handleOnGuide}>
             <Flex justify="space-between">
                 <Flex gap={8}>
                     <Icon name="Book" />

--- a/src/core/Menu.ts
+++ b/src/core/Menu.ts
@@ -1,0 +1,14 @@
+export const Menus = [
+    {
+        label: "Home",
+        path: "/",
+    },
+    {
+        label: "Extension",
+        path: "/extension",
+    },
+    {
+        label: "Pricing",
+        path: "/price",
+    },
+] as const;

--- a/src/layouts/FooterLayout.tsx
+++ b/src/layouts/FooterLayout.tsx
@@ -1,35 +1,11 @@
-import Header from "@/components/Header/Header";
 import Footer from "@/components/Footer/Footer";
 import { Outlet } from "react-router-dom";
-import styled from "styled-components";
 
 export default function FooterLayout() {
     return (
-        <LayoutContainer>
-            <Header />
-            <ContentWrapper>
-                <Outlet />
-            </ContentWrapper>
+        <>
+            <Outlet />
             <Footer />
-        </LayoutContainer>
+        </>
     );
 }
-
-const LayoutContainer = styled.div`
-    position: relative;
-    min-height: 100vh; // 전체 뷰포트 높이를 차지하도록 설정
-    display: flex;
-    flex-direction: column;
-`;
-
-const ContentWrapper = styled.div`
-    flex: 1; // 남은 공간을 모두 차지하도록 설정
-`;
-
-export const Wrapper = styled.div`
-    width: 100%;
-    height: 100%;
-    max-width: 1080px;
-    padding-top: 60px;
-    margin: 0 auto;
-`;

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -1,11 +1,16 @@
 import Header from "@/components/Header/Header";
+import Sidebar from "@/components/Sidebar/Sidebar";
+import { useState } from "react";
 import { Outlet } from "react-router-dom";
 import styled from "styled-components";
 
 export default function Layout() {
+    const [isOpen, setIsOpen] = useState(false);
+
     return (
         <LayoutContainer>
-            <Header />
+            <Header onOpen={() => setIsOpen(true)} />
+            <Sidebar open={isOpen} onClose={() => setIsOpen(false)} />
             <ContentWrapper>
                 <Outlet />
             </ContentWrapper>

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -14,16 +14,6 @@ import PromptPage from "@/pages/prompt";
 const router = createBrowserRouter([
     {
         path: "/",
-        element: <FooterLayout />,
-        errorElement: <NotFound />,
-        children: [
-            { path: "/", element: <HomePage /> },
-            { path: "/extension", element: <ExtensionPage /> },
-            { path: "/price", element: <PricePage /> },
-        ],
-    },
-    {
-        path: "/",
         element: <Layout />,
         children: [
             {
@@ -51,6 +41,16 @@ const router = createBrowserRouter([
                 ),
             },
             { path: "/prompt/:promptId", element: <PromptPage /> },
+            {
+                path: "/",
+                element: <FooterLayout />,
+                errorElement: <NotFound />,
+                children: [
+                    { path: "/", element: <HomePage /> },
+                    { path: "/extension", element: <ExtensionPage /> },
+                    { path: "/price", element: <PricePage /> },
+                ],
+            },
         ],
     },
 ]);


### PR DESCRIPTION
## 🏆 Details
- 모바일 헤더를 위한 사이드바를 구현하였습니다 
- 작업하면서 layout도 `Layout.tsx`를 기본으로 사용하고, Footer 필요한 것들은 한번 더 감싸도록 수정하였습니다 (기존에는 각 레이아웃 따로 사용함) 
- 메뉴도 상수로 분리해두었습니다 

## 📸 Screenshot
| 모바일 |
| - |
|<video src="https://github.com/user-attachments/assets/eab85b86-be77-45f5-984a-f9eec6b7c367"/> |


