### PR TITLE
[프롬프트 상세] 포켓런 부가 기능

### DIFF
--- a/src/pages/home/components/Prompt/Prompt.tsx
+++ b/src/pages/home/components/Prompt/Prompt.tsx
@@ -4,6 +4,8 @@ import Play from "@/assets/svg/home/Play";
 import theme from "@/styles/theme";
 import * as S from "./styles";
 import { useNavigate } from "react-router-dom";
+import { useResetRecoilState } from "recoil";
+import { pocketRunState } from "@/states/pocketRunState";
 
 interface PromptProps {
     colored?: boolean;
@@ -27,10 +29,12 @@ const Prompt = ({
     id,
 }: PromptProps) => {
     const pointColor = colored ? theme.colors.primary : theme.colors.G_400;
+    const resetPocketRunState = useResetRecoilState(pocketRunState);
     const navigate = useNavigate();
 
     const handleClick = () => {
         navigate(`/prompt/${id}`);
+        resetPocketRunState();
     };
 
     return (

--- a/src/pages/prompt/components/PocketRunDropdown.tsx
+++ b/src/pages/prompt/components/PocketRunDropdown.tsx
@@ -7,11 +7,13 @@ import { Dropdown, Flex, MenuProps } from "antd";
 interface PocketRunDropdownProps {
     disabled: boolean;
     onSelect: (platform: string) => void;
+    secondRun: boolean;
 }
 
 export default function PocketRunDropdown({
     disabled,
     onSelect,
+    secondRun = false,
 }: PocketRunDropdownProps) {
     const handleOnSelect: MenuProps["onClick"] = ({ key }) => {
         onSelect(key);
@@ -42,9 +44,13 @@ export default function PocketRunDropdown({
                 size={44}
                 style={{ padding: "12px" }}
             >
-                <Flex gap={12} style={{ flex: 1 }}>
+                <Flex gap={12}>
                     <Logo width={24} fill="#AFB1C1" stroke="#AFB1C1" />
-                    <div style={{ flex: 1 }}>포켓런 하기</div>
+                    <div style={{ flex: 1 }}>
+                        {secondRun
+                            ? "변경된 프롬프트로 다시 실행하기"
+                            : "포켓런 하기"}
+                    </div>
                 </Flex>
             </Button>
         );
@@ -52,9 +58,13 @@ export default function PocketRunDropdown({
     return (
         <Dropdown menu={{ items, onClick: handleOnSelect }}>
             <Button width="100%" size={44} style={{ padding: "12px" }}>
-                <Flex gap={12} style={{ flex: 1 }}>
+                <Flex gap={12}>
                     <Logo width={24} fill="white" stroke="white" />
-                    <div style={{ flex: 1 }}>포켓런 하기</div>
+                    <div>
+                        {secondRun
+                            ? "변경된 프롬프트로 다시 실행하기"
+                            : "포켓런 하기"}
+                    </div>
                 </Flex>
             </Button>
         </Dropdown>

--- a/src/pages/prompt/components/ResultSection.tsx
+++ b/src/pages/prompt/components/ResultSection.tsx
@@ -1,16 +1,18 @@
 import Text from "@/components/common/Text/Text";
-import { pocketRunState } from "@/states/pocketRunState";
-import { Flex } from "antd";
+import { pocketRunLoadingState, pocketRunState } from "@/states/pocketRunState";
+import { Flex, Spin } from "antd";
+import { LoadingOutlined } from "@ant-design/icons";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
 export const ResultSection: React.FC = () => {
     const pocketRunRes = useRecoilValue(pocketRunState);
+    const pocketRunLoading = useRecoilValue(pocketRunLoadingState);
 
     return (
         <Flex vertical gap={16} style={{ height: "100%" }}>
             <Text font="h2_20_semi">포켓런 결과</Text>
-            {pocketRunRes[0].response.length === 0 ? (
+            {!pocketRunLoading && pocketRunRes[0].response.length === 0 ? (
                 <EmptyBox vertical gap={4} justify="center" align="center">
                     <Text font="b2_16_semi">아직 포켓런 결과가 없어요!</Text>
                     <Text font="b3_14_reg" color="G_400">
@@ -39,11 +41,40 @@ export const ResultSection: React.FC = () => {
                                 </Chip>
                             ))}
                         </ChipWrapper>
-                        <Box>
-                            <Text font="b2_16_med" color={"G_700"} key={index}>
-                                {res.response}
-                            </Text>
-                        </Box>
+
+                        {index === pocketRunRes.length - 1 &&
+                        pocketRunLoading ? (
+                            <LoadingBox>
+                                <Spin
+                                    indicator={
+                                        <LoadingOutlined
+                                            style={{
+                                                fontSize: 36,
+                                                marginBottom: 16,
+                                            }}
+                                            spin
+                                        />
+                                    }
+                                />
+                                <Text font="b1_18_semi">
+                                    포켓런 결과를 불러오고 있어요
+                                </Text>
+                                <Text font="b3_14_reg">
+                                    최상의 결과를 불러올게요! 잠시만
+                                    기다려주세요
+                                </Text>
+                            </LoadingBox>
+                        ) : (
+                            <Box>
+                                <Text
+                                    font="b2_16_med"
+                                    color={"G_700"}
+                                    key={index}
+                                >
+                                    {res.response}
+                                </Text>
+                            </Box>
+                        )}
                     </>
                 ))
             )}
@@ -63,17 +94,26 @@ const EmptyBox = styled(Flex)`
 const Box = styled(Flex)`
     border-radius: 8px;
     border: 1.5px solid var(--primary-20, #e3e6fb);
-
     width: 100%;
-    height: 100%;
     padding: 16px;
     flex-direction: column;
     gap: 8px;
 `;
 
+const LoadingBox = styled.div`
+    display: flex;
+    border-radius: 8px;
+    background: var(--gray-50, #f7f8f9);
+    width: 100%;
+    height: 323px;
+    margin: auto;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+`;
+
 const ChipWrapper = styled.div`
     width: 100%;
-    height: 100%;
     display: flex;
     flex-direction: row;
     gap: 8px;

--- a/src/pages/prompt/components/ResultSection.tsx
+++ b/src/pages/prompt/components/ResultSection.tsx
@@ -4,10 +4,23 @@ import { Flex, Spin } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
+import Icon from "@/pages/home/components/common/Icon";
+import { copyClipboard } from "@/utils/promptUtils";
+import Button from "@/components/common/Button/Button";
 
 export const ResultSection: React.FC = () => {
     const pocketRunRes = useRecoilValue(pocketRunState);
     const pocketRunLoading = useRecoilValue(pocketRunLoadingState);
+
+    const handleClickCopy = (result: string) => {
+        copyClipboard(result)
+            .then(() => {
+                console.log("클립보드 복사 성공");
+            })
+            .catch((err) => {
+                console.error("클립보드 복사 실패:", err);
+            });
+    };
 
     return (
         <Flex vertical gap={16} style={{ height: "100%" }}>
@@ -65,15 +78,38 @@ export const ResultSection: React.FC = () => {
                                 </Text>
                             </LoadingBox>
                         ) : (
-                            <Box>
-                                <Text
-                                    font="b2_16_med"
-                                    color={"G_700"}
-                                    key={index}
+                            <>
+                                <Box>
+                                    <Text
+                                        font="b2_16_med"
+                                        color={"G_700"}
+                                        key={index}
+                                    >
+                                        {res.response}
+                                    </Text>
+                                </Box>
+                                <Button
+                                    onClick={() =>
+                                        handleClickCopy(res.response)
+                                    }
+                                    width="143px"
+                                    size={44}
+                                    suffix={
+                                        <Icon
+                                            name="Copy"
+                                            size={20}
+                                            color="primary_100"
+                                        />
+                                    }
+                                    style={{
+                                        padding: "8px 12px 8px 16px",
+                                        margin: "auto 0 auto auto",
+                                    }}
+                                    hierarchy="normal"
                                 >
-                                    {res.response}
-                                </Text>
-                            </Box>
+                                    결과 복사하기
+                                </Button>
+                            </>
                         )}
                     </>
                 ))

--- a/src/pages/prompt/index.tsx
+++ b/src/pages/prompt/index.tsx
@@ -103,10 +103,10 @@ const BoxContainer = styled.div`
 
     @media (min-width: 1080px) {
         &:nth-child(1) {
-            flex: 3;
+            flex: 3.5;
         }
         &:nth-child(2) {
-            flex: 7;
+            flex: 6.5;
         }
     }
 

--- a/src/states/pocketRunState.ts
+++ b/src/states/pocketRunState.ts
@@ -11,3 +11,8 @@ export const pocketRunState = atom<PocketRunReturnTypes[]>({
         },
     ],
 });
+
+export const pocketRunLoadingState = atom({
+    key: "pocketRunLoadingState",
+    default: false,
+});


### PR DESCRIPTION

## 🏆 Details

- 포켓런 로딩 동작 구현
- 최초 포켓런 이후 입력값 변경시 버튼 string 수정
   - 최초 포켓런시: 포켓런 하기
   - 최초 포켓런 이후 입력값이 변경되었을 경우: 변경된 프롬프트로 다시 실행하기 
   - `Need Review` form watch와 useRef 사용해서 입력값을 비교했는데 더 간결한 방법이 있을까요?
   
- 프롬프트 상세 페이지 접근시 포켓련 결과 상태 초기화
    - 포켓런 실행해서 저장해둔 상태가 있을 경우 다른 프롬프트로 이동시 해당 상태가 렌더링되는 이슈 방지
    - `Need Review` 프롬프트 onClick 이벤트 발생시 걸어두었는데 다른 루트로 프롬프트 상세 페이지 접근 가능성이 있을까요? 

- 결과 복사 버튼 구현
    - 기획팀에 확인 결과 복사 성공시 toast 버튼이 나와야 한다고 합니다! 요부분 세부 디자인 요청해놓은 상태로 다음 스프린트때 일괄 수정해놓을게용 

## 📸 Screenshot


https://github.com/user-attachments/assets/07b59575-f358-4dd1-bb95-2fe9ca45083c



