### PR TITLE
[이슈 해결] 홈화면 다크모드시 배경색 이슈, 포켓런 결과란 입력값 넘칠 경우 스크롤 처리

### DIFF
--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -24,9 +24,10 @@ export default function HomePage() {
 const HomeWrapper = styled.div`
     ${({ theme }) => theme.mixins.flexBox()}
     gap: 40px;
-    margin-top: 92px;
+    padding-top: 92px;
     align-items: start;
     width: 100vw;
+    background-color: white;
 `;
 
 const HomeContentWrapper = styled.div`

--- a/src/pages/prompt/components/ResultSection.tsx
+++ b/src/pages/prompt/components/ResultSection.tsx
@@ -46,7 +46,12 @@ export const ResultSection: React.FC = () => {
                                 </Text>
                             </ModelChip>
                             {Object.entries(res.context).map(([key, value]) => (
-                                <Chip key={key}>
+                                <Chip
+                                    key={key}
+                                    style={{
+                                        overflow: "scroll",
+                                    }}
+                                >
                                     <Text font="b3_14_reg" color="G_500">
                                         <span>{key}: </span>
                                         {value}


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   홈 컴포넌트에 배경색 지정
-   포켓런 결과란의 입력값 표시 컴포넌트에 overflow: scroll 처리

## 📸 Screenshot

https://github.com/user-attachments/assets/fd174745-a6ec-40db-b807-4e8e19661400
