### PR TITLE
[이슈 해결] 포켓런 실행/결과란 높이 이슈, 코드블록 overflow 이슈, 헤더 유저 버튼 hover, selected 추가

### DIFF
--- a/src/components/Header/User/User.tsx
+++ b/src/components/Header/User/User.tsx
@@ -1,5 +1,5 @@
 import { useUser } from "@/hooks/useUser";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import Text from "@/components/common/Text/Text";
 import Icon from "@/components/common/Icon";
@@ -8,29 +8,47 @@ export default function User() {
     const { userData } = useUser();
     const navigate = useNavigate();
 
+    const location = useLocation();
+    const isSelected = location.pathname.includes("my");
+
     return (
-        <Wrapper onClick={() => navigate("/my")}>
-            <UserWrapper>
-                <Text font="b3_14_reg" color="G_800">
+        <Wrapper $isSelected={isSelected}>
+            <UserWrapper onClick={() => navigate("/my")}>
+                <Text
+                    font="b3_14_reg"
+                    color={isSelected ? "primary_100" : "G_800"}
+                >
                     {userData.user?.nickname}
                 </Text>
-                <Icon name="User" color="G_800" />
+                <Icon
+                    name="User"
+                    color={isSelected ? "primary_100" : "G_800"}
+                />
             </UserWrapper>
         </Wrapper>
     );
 }
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ $isSelected: boolean }>`
     ${({ theme }) => theme.mixins.flexBox()};
     gap: 10px;
-
     cursor: pointer;
+
+    background-color: ${({ $isSelected }) =>
+        $isSelected ? "#F2F3FD" : "#f1f2f6"};
+    border-radius: 8px;
+    border: ${({ $isSelected }) =>
+        $isSelected && "1.5px solid var(--primary-50, #BBC0F5)"};
+
+    :hover {
+        background-color: ${({ $isSelected }) => !$isSelected && "#dee0e8"};
+        border-radius: 8px;
+    }
 `;
 
 const UserWrapper = styled.div`
     ${({ theme }) => theme.mixins.flexBox()};
+    cursor: pointer;
     padding: 8px 8px 8px 12px;
     gap: 10px;
-    background-color: #f1f2f6;
-    border-radius: 8px;
 `;

--- a/src/components/common/Text/Text.tsx
+++ b/src/components/common/Text/Text.tsx
@@ -101,20 +101,24 @@ const MarkdownWrapper = styled.div`
 
     code {
         background: #f5f5f5;
-        border: 1px solid #e1e1e1;
         padding: 0.1em 0.2em;
         border-radius: 3px;
-        font-family: "Courier New", Courier, monospace;
+        font-family: "Fira Code", "Source Code Pro", "Menlo", "Consolas",
+            "Courier New", monospace;
         font-size: 0.95em;
     }
 
     pre {
         background: #f5f5f5;
         border: 1px solid #e1e1e1;
-        padding: 0.6em; /* 코드블록 패딩을 줄임 */
+        padding: 0.6em;
         border-radius: 4px;
-        overflow-x: auto;
+        max-width: 100%;
+        overflow-y: auto;
+        overflow-x: hidden;
         margin: 0.3em 0;
+        word-wrap: break-word;
+        white-space: pre-wrap;
     }
 `;
 

--- a/src/pages/prompt/index.tsx
+++ b/src/pages/prompt/index.tsx
@@ -118,4 +118,6 @@ const BoxContainer = styled.div`
     @media (max-width: 1080px) {
         width: 100%;
     }
+
+    height: fit-content;
 `;


### PR DESCRIPTION

## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   포켓런 실행/결과란 높이 이슈
     - 실행란 및 결과란이 같은 높이로 적용되어 결과가 길어질 경우 실행란도 길어지는 이슈
     - height: fit-content해서 내용에 맞는 높이로 적용
    
-   코드블록 overflow 이슈
     - 포켓런 결과란에 표시되는 코드블럭이 길어질 경우 줄바꿈되지 않는 이슈
     - overflow 관련 적용
     - 이외에 보다 chat GPT와 유사하도록 폰트 수정 
  
- 헤더 유저 버튼에 hover, selected 상태 추가

## 📸 Screenshot

https://github.com/user-attachments/assets/fe949a99-02d3-4a1a-a277-b97181c4f935


https://github.com/user-attachments/assets/48764ef7-3ff4-404b-8fbc-9c0b4fa644a2

