### PR TITLE
[이슈] 애드센스 추가되어 발생한 레이아웃 이슈 수정

### DIFF
--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -36,6 +36,7 @@ ${reset}
     font-family: Pretendard;
     font-style: normal;
 
+
     scrollbar-width: none; /* 파이어폭스 스크롤바 숨김 */
     margin: 0 auto;
     padding: 0;
@@ -45,6 +46,8 @@ ${reset}
 
     /* 버튼 클릭 시 색 제거 */
     -webkit-tap-highlight-color: rgba(0,0,0,0);
+
+    align-items: flex-start;
 }
 #root::-webkit-scrollbar {
     display: none; /* 크롬, 사파리, 오페라, 엣지 스크롤바 숨김 */


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   애드센스가 추가될 때 `height: auto !important; min-height: 0px !important;` 가 자동으로 붙는 것 같아요.
레이아웃이 중앙에 배치되는 이슈가 있어서 globalStyle 수정해두었습니다.

## 📸 Screenshot

-   이슈 발생 모습

![image](https://github.com/user-attachments/assets/a38e09b6-fad7-439c-97ad-dfac833c79c2)
