### PR TITLE
[이슈] useSearchParams Suspense 경고 해결

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import PaginatedPromptSection from "@/components/home/prompt/PaginatedPromptSect
 
 import useToast from "@/hooks/useToast";
 import useDeviceSize from "@/hooks/useDeviceSize";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useResetRecoilState } from "recoil";
 import {
     searchedCategoryState,
@@ -22,13 +22,16 @@ export default function HomePage() {
     const { isUnderTablet } = useDeviceSize();
     const resetSearchedKeyword = useResetRecoilState(searchedKeywordState);
     const resetSearchedCategory = useResetRecoilState(searchedCategoryState);
+
     const searchParams = useSearchParams();
     const [isInitialized, setIsInitialized] = useState(false);
 
     // voc modal open
     const [isVocModalOpen, setIsVocModalOpen] = useState(false);
 
-    const shouldReset = searchParams.get("reset") !== "false";
+    const shouldReset = useMemo(() => {
+        return searchParams.get("reset") !== "false";
+    }, [searchParams]);
 
     useEffect(() => {
         if (shouldReset) {


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   `⨯ useSearchParams() should be wrapped in a suspense boundary at page "/".`
    -   useSearchParams 는 클라이언트에서만 실행되어야 하는데, 직접 참조되는 코드가 있어서 이슈 발생
    -   useMemo나 useEffect로 감싸면 클라이언트에서만 실행되도록 보장

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/09e4b78e-3bde-407b-9a5b-6117374cb52b)