### PR TITLE
[이슈] useEffect로 useSearchParams Suspense 오류 해결하도록 변경

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,32 +5,31 @@ import { Wrapper } from "@components/layout/LayoutClient";
 import styled from "styled-components";
 import PaginatedPromptSection from "@/components/home/prompt/PaginatedPromptSection";
 
-import useToast from "@/hooks/useToast";
 import useDeviceSize from "@/hooks/useDeviceSize";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useResetRecoilState } from "recoil";
 import {
     searchedCategoryState,
     searchedKeywordState,
 } from "@/states/searchState";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import HomeLnb from "@/components/lnb/HomeLnb";
 import Icon from "../components/common/Icon";
 import VocModal from "@/components/home/VocModal";
+import { useSearchParams } from "next/navigation";
 
 export default function HomePage() {
     const { isUnderTablet } = useDeviceSize();
     const resetSearchedKeyword = useResetRecoilState(searchedKeywordState);
     const resetSearchedCategory = useResetRecoilState(searchedCategoryState);
-
     const searchParams = useSearchParams();
+    const [shouldReset, setShouldReset] = useState<boolean>(false);
     const [isInitialized, setIsInitialized] = useState(false);
 
     // voc modal open
     const [isVocModalOpen, setIsVocModalOpen] = useState(false);
 
-    const shouldReset = useMemo(() => {
-        return searchParams.get("reset") !== "false";
+    useEffect(() => {
+        setShouldReset(searchParams.get("reset") !== "false");
     }, [searchParams]);
 
     useEffect(() => {


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   `⨯ useSearchParams() should be wrapped in a suspense boundary at page "/".`
    -   useSearchParams 는 클라이언트에서만 실행되어야 하는데, 직접 참조되는 코드가 있어서 이슈 발생
    -   useEffect로 감싸면 클라이언트에서만 실행되도록 보장

## 📸 Screenshot

![image](https://github.com/user-attachments/assets/09e4b78e-3bde-407b-9a5b-6117374cb52b)