### PR TITLE
[이슈] useSearchParams 사용시 Suspense로 감싸도록 변경

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import PaginatedPromptSection from "@/components/home/prompt/PaginatedPromptSection";
 
 import useDeviceSize from "@/hooks/useDeviceSize";
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useResetRecoilState } from "recoil";
 import {
     searchedCategoryState,
@@ -18,6 +18,14 @@ import VocModal from "@/components/home/VocModal";
 import { useSearchParams } from "next/navigation";
 
 export default function HomePage() {
+    return (
+        <Suspense fallback={null}>
+            <HomeContent />
+        </Suspense>
+    );
+}
+
+function HomeContent() {
     const { isUnderTablet } = useDeviceSize();
     const resetSearchedKeyword = useResetRecoilState(searchedKeywordState);
     const resetSearchedCategory = useResetRecoilState(searchedCategoryState);


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-    `⨯ useSearchParams() should be wrapped in a suspense boundary at page "/".`
     -    useSearchParams는 클라이언트에서만 실행되어야 하며, SSR 방지를 위해 Suspense로 감싸야 함
     -    Suspense 사용시 데이터 로드까지 fallback 띄우므로 렌더링 속도 느려질 가능성 있음
     -    다만 현재 코드에서는 이미 hydration 에러 방지를 위해 초기 렌더링을 막고 있어서 추가


## 📚 Reference

https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout
