### PR TITLE
[이슈] 즐겨찾기 버튼 id와 api 요청 로직 분리 및 즐겨찾기 토스트 추가

### DIFF
--- a/src/components/prompt/BookmarkButton.tsx
+++ b/src/components/prompt/BookmarkButton.tsx
@@ -9,28 +9,30 @@ import { Flex, message } from "antd";
 import { AxiosError } from "axios";
 import Icon from "../common/Icon";
 import Link from "next/link";
+import useToast from "@/hooks/useToast";
 
 interface BookmarkButtonProps {
     is_starred: boolean;
-    id: string;
+    promptId: string;
 }
 export default function BookmarkButton({
     is_starred,
-    id,
+    promptId,
 }: BookmarkButtonProps) {
     const queryClient = useQueryClient();
 
     const [messageApi, contextHolder] = message.useMessage();
     const { openModal, closeModal } = useModal();
+    const showToast = useToast();
 
     const handleOnClick = () => {
-        if (!id) {
+        if (!promptId) {
             messageApi.error("존재하지 않은 프롬프트입니다.");
             return;
         }
 
-        if (is_starred) deleteStar(id);
-        else postStar(id);
+        if (is_starred) deleteStar(promptId);
+        else postStar(promptId);
     };
 
     const openLimitModal = (message: string) => {
@@ -76,7 +78,15 @@ export default function BookmarkButton({
                 return;
             }
 
-            queryClient.invalidateQueries({ queryKey: PROMPT_KEYS.detail(id) });
+            showToast({
+                title: "프롬프트가 즐겨찾기 되었어요.",
+                subTitle: "",
+                iconName: "TickCircle",
+            });
+
+            queryClient.invalidateQueries({
+                queryKey: PROMPT_KEYS.detail(promptId),
+            });
             queryClient.invalidateQueries({ queryKey: PROMPT_KEYS.lists() });
         },
         onError: (error) => {
@@ -103,7 +113,15 @@ export default function BookmarkButton({
                 return;
             }
 
-            queryClient.invalidateQueries({ queryKey: PROMPT_KEYS.detail(id) });
+            showToast({
+                title: "프롬프트 즐겨찾기가 해제되었어요.",
+                subTitle: "",
+                iconName: "TickCircle",
+            });
+
+            queryClient.invalidateQueries({
+                queryKey: PROMPT_KEYS.detail(promptId),
+            });
             queryClient.invalidateQueries({ queryKey: PROMPT_KEYS.lists() });
         },
         onError: (error) => {
@@ -128,6 +146,7 @@ export default function BookmarkButton({
                     suffix={<Icon name="Bookmark" color="white" size={20} />}
                     style={{ padding: "12px" }}
                     onClick={handleOnClick}
+                    id="saved-toggle"
                 />
                 {contextHolder}
             </>
@@ -141,6 +160,7 @@ export default function BookmarkButton({
                 suffix={<Icon name="Bookmark" color="primary_100" size={20} />}
                 style={{ padding: "12px" }}
                 onClick={handleOnClick}
+                id="saved-toggle"
             />
             {contextHolder}
         </>

--- a/src/components/prompt/TopSection.tsx
+++ b/src/components/prompt/TopSection.tsx
@@ -64,8 +64,7 @@ export const TopSection = ({ prompt }: TopSectionProps) => {
                             onClick={handleShare}
                         />
                         <BookmarkButton
-                            // id={prompt.id}
-                            id="saved-toggle"
+                            promptId={prompt.id}
                             is_starred={prompt.is_starred_by_user}
                         />
 


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   as-is
    -   즐겨찾기 버튼이 아닌 즐겨찾기 컴포넌트에 gtm Id 설정되어 gtm 추적 불가
    -   즐겨찾기 컴포넌트에 전달되어야 하는 prompt Id가 gtm id로 변경되어 즐겨찾기 api 쿼리스트링에 잘못된 값 전달됨

-   to-be
    -   즐겨찾기 버튼 자체에 gtm id 지정하도록 변경
    -   즐겨찾기 컴포넌트에는 기존대로 promptId 전달하도록 변경

-   기능 추가
    -   즐겨찾기 완료 / 즐겨찾기 해제 완료시 토스트 추가
        - 즐겨찾기: '프롬프트가 즐겨찾기 되었어요.'
        - 해제: '프롬프트 즐겨찾기가 해제되었어요.' 


## ScreenShots

![image](https://github.com/user-attachments/assets/7649358a-610b-4304-830c-156a89e209e2)
