### PR TITLE
[이슈] 검색 결과가 저장된 프롬프트 화면에 렌더링되는 이슈

### DIFF
--- a/src/components/home/prompt/PaginatedPromptSection.tsx
+++ b/src/components/home/prompt/PaginatedPromptSection.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/states/searchState";
 import { useRecoilValue } from "recoil";
 import { ViewType } from "@/apis/prompt/prompt.model";
+import { usePathname } from "next/navigation";
 
 interface PaginatedPromptSectionProps {
     viewType?: ViewType;
@@ -16,16 +17,21 @@ const PaginatedPromptSection = ({
 }: PaginatedPromptSectionProps) => {
     const searchedKeyword = useRecoilValue(searchedKeywordState);
     const searchedCategory = useRecoilValue(searchedCategoryState);
+    const pathname = usePathname();
 
     const promptContent = () => {
-        if (searchedKeyword) {
+        if (searchedKeyword && pathname === "/") {
             // 키워드 검색시
             return (
                 <SectionWrapper>
                     <PaginatedPrompt searchType="search" viewType={viewType} />
                 </SectionWrapper>
             );
-        } else if (!!searchedCategory && searchedCategory !== "total") {
+        } else if (
+            !!searchedCategory &&
+            searchedCategory !== "total" &&
+            pathname === "/"
+        ) {
             // 카테고리 칩 검색시
             return (
                 <SectionWrapper>


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   검색어 입력 후 저장한 프롬프트 화면으로 이동시 검색 결과 프롬프트 리스트가 렌더링됨
    -   검색어 세션 유지 기능 추가되면서 프롬프트 리스트를 조건부 렌더링 로직 수정 필요
    -   현재 pathname이 홈 화면에 해당할 때 검색 결과 렌더링되도록 수정

## 📸 Screenshot

- 수정 전 이슈 화면
![image](https://github.com/user-attachments/assets/ba5b778e-13bc-4abf-aa65-11bc6cb76622)

