### PR TITLE
[이슈] text 컴포넌트에 onClick 이벤트 전달될 경우 pointer-events 허용

### DIFF
--- a/src/components/common/Text/Text.tsx
+++ b/src/components/common/Text/Text.tsx
@@ -17,7 +17,12 @@ export default function Text({
     ...props
 }: PropsWithChildren<TextProps>) {
     return (
-        <StyledText $font={font} $color={color} {...props}>
+        <StyledText
+            $font={font}
+            $color={color}
+            $hasEvent={!!props.onClick}
+            {...props}
+        >
             {markdown ? (
                 <MarkdownWrapper>
                     <ReactMarkdown components={markdownStyles}>
@@ -31,11 +36,15 @@ export default function Text({
     );
 }
 
-const StyledText = styled.div<{ $font: string; $color: string }>`
+const StyledText = styled.div<{
+    $font: string;
+    $color: string;
+    $hasEvent: boolean;
+}>`
     ${({ theme, $font }) => theme.fonts[$font]};
     color: ${({ theme, $color }) => theme.colors[$color]};
     white-space: pre-wrap;
-    pointer-events: none;
+    pointer-events: ${({ $hasEvent }) => ($hasEvent ? "all" : "none")};
 `;
 
 const MarkdownWrapper = styled.div`


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   이슈 원인
    -   저장한 프롬프트 gtm 추적시 click element가 text 컴포넌트로 잡혔던 히스토리
    -   상기 이슈 해결을 위해 text 컴포넌트의 Pointer-events 해제해놓음
    -   다만 특정 드롭다운에서 button을 넣지 않고 text 컴포넌트에 직접 Onclick 이벤트 할당해서 생긴 문제

-  해결
    -   onclick 이벤트 전달시 pointer-events 허용으로 변경
