### PR TITLE
[기능 추가] Query key 무효화하는 hooks 추가

### DIFF
--- a/src/components/promptNew-v2/index.tsx
+++ b/src/components/promptNew-v2/index.tsx
@@ -33,6 +33,11 @@ import PromptNewLnb from "../lnb/PromptNewLnb";
 import FormFirstSection from "./FormFirstSection";
 import FormSecSection from "./FormSecSection";
 import FormThirdSecion from "./FormThirdSecion";
+import { useInvalidateQueryKeys } from "@/hooks/queries/useInvalidateQueryKeys";
+import {
+    PROMPT_KEYS,
+    PROMPT_QUERY_KEYS_FOR_PREFETCH,
+} from "@/hooks/queries/QueryKeys";
 
 interface PromptNewPageProps {
     isEdit: boolean;
@@ -71,9 +76,20 @@ export default function NewPromptClient({
     const promptTemplateValue = form.watch("prompt_template") || "";
     const isValid = promptTemplateValue.length > 0;
 
+    const queryKey = isUnderTablet
+        ? PROMPT_QUERY_KEYS_FOR_PREFETCH.ALL_PROMPTS_MOBILE
+        : PROMPT_QUERY_KEYS_FOR_PREFETCH.ALL_PROMPTS;
+    const resetPromptListQueryKey = useInvalidateQueryKeys(
+        PROMPT_KEYS.list(queryKey)
+    );
+    const resetPromptQueryKey = useInvalidateQueryKeys(
+        PROMPT_KEYS.detail(promptId ?? "")
+    );
+
     const { mutate: createPromptMutate } = usePostPrompt({
         onSuccess(res) {
             console.log("Success", res);
+            resetPromptListQueryKey();
             showToast({
                 title: "프롬프트 등록이 완료되었어요.",
                 subTitle: "",
@@ -114,6 +130,8 @@ export default function NewPromptClient({
     const { mutate: updatePromptMutate } = usePutPrompt({
         onSuccess(res) {
             console.log("Success", res);
+            resetPromptQueryKey();
+            resetPromptListQueryKey();
             showToast({
                 title: "프롬프트 수정이 완료되었어요.",
                 subTitle: "",

--- a/src/hooks/queries/useInvalidateQueryKeys.tsx
+++ b/src/hooks/queries/useInvalidateQueryKeys.tsx
@@ -1,0 +1,11 @@
+import { QueryKey, useQueryClient } from "@tanstack/react-query";
+
+export const useInvalidateQueryKeys = (queryKey: QueryKey) => {
+    const queryClient = useQueryClient();
+
+    return () => {
+        queryClient.invalidateQueries({
+            queryKey: queryKey,
+        });
+    };
+};


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   캐싱된 서버 상태를 무효화해야 할 경우 사용할 수 있는 useInvalidateQueryKeys 추가
    -   예시) 프롬프트 수정시 해당 Query Key(프롬프트 id)로 캐싱된 프롬프트 detail 값 무효화
