### PR TITLE
fix : search 버그 수정

### DIFF
--- a/src/app/extension/page.tsx
+++ b/src/app/extension/page.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+    keywordState,
+    searchedCategoryState,
+    searchedKeywordState,
+} from "@/states/searchState";
 import Extension1 from "@components/extension/Extension1";
 import Extension2 from "@components/extension/Extension2";
 import Extension3 from "@components/extension/Extension3";
@@ -10,13 +15,25 @@ import Extension7 from "@components/extension/Extension7";
 import Extension8 from "@components/extension/Extension8";
 import Extension9 from "@components/extension/Extension9";
 import { useEffect, useState } from "react";
+import { useRecoilState } from "recoil";
 import styled from "styled-components";
 
 const ExtensionPage = () => {
     const [isClient, setIsClient] = useState(false);
+    const [keyword, setKeyword] = useRecoilState(keywordState);
+    const [searchedKeyword, setSearchedKeyword] =
+        useRecoilState(searchedKeywordState);
+    const [searchedCategory, setSearchedCategory] = useRecoilState(
+        searchedCategoryState
+    );
 
     useEffect(() => {
         setIsClient(true); // 클라이언트에서만 렌더링 허용
+        return () => {
+            setKeyword("");
+            setSearchedKeyword("");
+            setSearchedCategory("");
+        };
     }, []);
 
     if (!isClient) {

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -1,24 +1,30 @@
 "use client";
 
-import Text from "@/components/common/Text/Text";
-import styled from "styled-components";
-import { Flex } from "antd";
-import Input from "@/components/common/Input/Input";
-import { useEffect, useState } from "react";
-import { useUser } from "@/hooks/useUser";
+import { getUser } from "@/apis/auth/auth";
 import Button from "@/components/common/Button/Button";
 import Icon from "@/components/common/Icon";
+import Input from "@/components/common/Input/Input";
+import Text from "@/components/common/Text/Text";
+import { useDeviceSize } from "@/components/DeviceContext";
 import PromptListSection from "@/components/home/prompt/PromptListSection";
+import MyLnb from "@/components/lnb/MyLnb";
 import { usePutNickname } from "@/hooks/mutations/usePutNickname";
 import useToast from "@/hooks/useToast";
+import { useUser } from "@/hooks/useUser";
+import {
+    keywordState,
+    searchedCategoryState,
+    searchedKeywordState,
+} from "@/states/searchState";
 import {
     getLocalStorage,
     LOCALSTORAGE_KEYS,
     removeLocalStorage,
 } from "@/utils/storageUtils";
-import { getUser } from "@/apis/auth/auth";
-import MyLnb from "@/components/lnb/MyLnb";
-import { useDeviceSize } from "@/components/DeviceContext";
+import { Flex } from "antd";
+import { useEffect, useState } from "react";
+import { useRecoilState } from "recoil";
+import styled from "styled-components";
 // import { isValidNickname } from "@/utils/textUtils";
 
 const MyPage = () => {
@@ -27,6 +33,22 @@ const MyPage = () => {
     const { isUnderTablet, isMobile } = useDeviceSize();
     const showToast = useToast();
     const [isInitialized, setIsInitialized] = useState(false);
+
+    const [keyword, setKeyword] = useRecoilState(keywordState);
+    const [searchedKeyword, setSearchedKeyword] =
+        useRecoilState(searchedKeywordState);
+    const [searchedCategory, setSearchedCategory] = useRecoilState(
+        searchedCategoryState
+    );
+
+    useEffect(() => {
+        setIsInitialized(true);
+        return () => {
+            setKeyword("");
+            setSearchedKeyword("");
+            setSearchedCategory("");
+        };
+    }, []);
 
     const getUserData = () => {
         const access_token = getLocalStorage(LOCALSTORAGE_KEYS.ACCESS_TOKEN);
@@ -81,10 +103,6 @@ const MyPage = () => {
         // }
         updateNickname(nickname);
     };
-
-    useEffect(() => {
-        setIsInitialized(true);
-    }, []);
 
     if (!isInitialized) return null; // hydration 에러 방지
 

--- a/src/app/price/page.tsx
+++ b/src/app/price/page.tsx
@@ -1,18 +1,36 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import styled from "styled-components";
+import Text from "@/components/common/Text/Text";
 import { Wrapper } from "@/components/layout/LayoutClient";
-import Plan from "@/components/price/plan/Plan";
 import FAQ from "@/components/price/FAQ";
 import Footer from "@/components/price/Footer";
-import Text from "@/components/common/Text/Text";
+import Plan from "@/components/price/plan/Plan";
+import {
+    keywordState,
+    searchedCategoryState,
+    searchedKeywordState,
+} from "@/states/searchState";
+import React, { useEffect, useState } from "react";
+import { useRecoilState } from "recoil";
+import styled from "styled-components";
 
 const PricePage: React.FC = () => {
     const [isClient, setIsClient] = useState(false);
+    const [keyword, setKeyword] = useRecoilState(keywordState);
+    const [searchedKeyword, setSearchedKeyword] =
+        useRecoilState(searchedKeywordState);
+    const [searchedCategory, setSearchedCategory] = useRecoilState(
+        searchedCategoryState
+    );
 
     useEffect(() => {
         setIsClient(true); // 클라이언트에서만 렌더링 허용
+
+        return () => {
+            setKeyword("");
+            setSearchedKeyword("");
+            setSearchedCategory("");
+        };
     }, []);
 
     if (!isClient) {

--- a/src/app/saved-prompt/page.tsx
+++ b/src/app/saved-prompt/page.tsx
@@ -1,17 +1,34 @@
 "use client";
 
-import HomeLnb from "@/components/lnb/HomeLnb";
 import PromptListSection from "@/components/home/prompt/PromptListSection";
+import HomeLnb from "@/components/lnb/HomeLnb";
+import {
+    keywordState,
+    searchedCategoryState,
+    searchedKeywordState,
+} from "@/states/searchState";
 import { useDeviceSize } from "@components/DeviceContext";
-import styled from "styled-components";
 import { useEffect, useState } from "react";
+import { useRecoilState } from "recoil";
+import styled from "styled-components";
 
 export default function SavedPromptPage() {
     const { isUnderTablet } = useDeviceSize();
     const [isInitialized, setIsInitialized] = useState(false);
+    const [keyword, setKeyword] = useRecoilState(keywordState);
+    const [searchedKeyword, setSearchedKeyword] =
+        useRecoilState(searchedKeywordState);
+    const [searchedCategory, setSearchedCategory] = useRecoilState(
+        searchedCategoryState
+    );
 
     useEffect(() => {
         setIsInitialized(true);
+        return () => {
+            setKeyword("");
+            setSearchedKeyword("");
+            setSearchedCategory("");
+        };
     }, []);
 
     if (!isInitialized) {

--- a/src/components/home/HomeContent.tsx
+++ b/src/components/home/HomeContent.tsx
@@ -1,24 +1,24 @@
 "use client";
 
-import Banner from "@components/home/banner/Banner";
+import PromptListSection from "@/components/home/prompt/PromptListSection";
 import { Wrapper } from "@components/layout/LayoutClient";
 import styled from "styled-components";
-import PromptListSection from "@/components/home/prompt/PromptListSection";
 
-import { Suspense, useEffect, useState } from "react";
-import { useResetRecoilState } from "recoil";
+import HomeSiderBar from "@/components/home/siderbarAd/HomeSiderBar";
+import VocModal from "@/components/home/VocModal";
+import HomeLnb from "@/components/lnb/HomeLnb";
 import {
+    keywordState,
     searchedCategoryState,
     searchedKeywordState,
 } from "@/states/searchState";
-import HomeLnb from "@/components/lnb/HomeLnb";
 import Icon from "@components/common/Icon";
-import VocModal from "@/components/home/VocModal";
-import { useSearchParams } from "next/navigation";
-import HomeSiderBar from "@/components/home/siderbarAd/HomeSiderBar";
 import { useDeviceSize } from "@components/DeviceContext";
-import SearchSection from "./SearchSection";
 import { Flex } from "antd";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useRecoilState, useResetRecoilState } from "recoil";
+import SearchSection from "./SearchSection";
 
 function HomeContent() {
     const { isUnderTablet } = useDeviceSize();
@@ -26,12 +26,19 @@ function HomeContent() {
     const resetSearchedCategory = useResetRecoilState(searchedCategoryState);
     const searchParams = useSearchParams();
     const [shouldReset, setShouldReset] = useState<boolean>(false);
+    const [keyword, setKeyword] = useRecoilState(keywordState);
+    const [searchedCategory, setSearchedCategory] = useRecoilState(
+        searchedCategoryState
+    );
 
     // voc modal open
     const [isVocModalOpen, setIsVocModalOpen] = useState(false);
 
     useEffect(() => {
-        setShouldReset(searchParams.get("reset") !== "false");
+        const keyword = searchParams.get("keyword") || "";
+        const category = searchParams.get("category") || "";
+        if (keyword) setKeyword(keyword);
+        if (category) setSearchedCategory(category);
     }, [searchParams]);
 
     useEffect(() => {

--- a/src/components/home/prompt/PromptList.tsx
+++ b/src/components/home/prompt/PromptList.tsx
@@ -12,21 +12,19 @@
  * - props에 따라 pagination, sort, tab 관리
  */
 
-import { Col, Flex, Pagination, Row, Select } from "antd";
-import Prompt from "./Prompt";
-import styled from "styled-components";
-import usePromptsListQuery, {
-    PromptQueryProps,
-} from "@/hooks/queries/prompts/usePromptsListQuery";
 import { SortType, ViewType } from "@/apis/prompt/prompt.model";
+import usePromptsListQuery from "@/hooks/queries/prompts/usePromptsListQuery";
+import {
+    searchedCategoryState,
+    searchedKeywordState,
+} from "@/states/searchState";
+import { sortTypeState } from "@/states/sortState";
+import { Col, Flex, Pagination, Row, Select } from "antd";
 import { useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
-import {
-    searchedKeywordState,
-    searchedCategoryState,
-} from "@/states/searchState";
+import styled from "styled-components";
 import EmptyPrompt from "./EmptyPrompt";
-import { sortTypeState } from "@/states/sortState";
+import Prompt from "./Prompt";
 
 interface PromptListProps {
     usePage?: boolean;
@@ -52,7 +50,7 @@ const PromptList = ({
     // 쿼리 파라미터 로직
     const queryParams = {
         viewType: viewType,
-        sortBy: defaultSortBy || sortBy, // 필요할 경우만 sortBy 사용
+        sortBy: defaultSortBy || sortBy,
         limit,
         ...(searchedKeyword ? { query: searchedKeyword } : {}),
         ...(searchCategory && searchCategory !== "total"
@@ -67,7 +65,12 @@ const PromptList = ({
         itemsPerPage,
         handlePageChange,
         isLoading,
+        // refetch,
     } = usePromptsListQuery(queryParams);
+
+    // useEffect(() => {
+    //     refetch();
+    // }, [searchedKeyword, searchCategory, refetch]);
 
     const handleSortChange = (value: SortType) => {
         setSortBy(value);

--- a/src/components/home/searchUI/SearchBar.tsx
+++ b/src/components/home/searchUI/SearchBar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // import Search from "@/assets/svg/home/Search";
 import Icon from "@/components/common/Icon";
 import Input from "@/components/common/Input/Input";
@@ -6,6 +8,7 @@ import {
     searchedCategoryState,
     searchedKeywordState,
 } from "@/states/searchState";
+import { useEffect } from "react";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import styled from "styled-components";
 
@@ -18,6 +21,12 @@ const SearchBar = () => {
         setSearchedKeyword(keyword);
         setSearchedCategory("");
     };
+
+    useEffect(() => {
+        return () => {
+            // setSearchedKeyword("");
+        };
+    }, []);
 
     return (
         <InputWrapper>

--- a/src/components/home/searchUI/SearchChips.tsx
+++ b/src/components/home/searchUI/SearchChips.tsx
@@ -1,7 +1,7 @@
 import Button from "@/components/common/Button/Button";
 import Text from "@/components/common/Text/Text";
-import { Categories } from "@/core/Prompt";
 import { useDeviceSize } from "@/components/DeviceContext";
+import { Categories } from "@/core/Prompt";
 import {
     searchedCategoryState,
     searchedKeywordState,
@@ -29,7 +29,7 @@ const SearchChips = () => {
     };
 
     return (
-        <SearchChipsWrapper $isVisible={searchedkeyword === ""}>
+        <SearchChipsWrapper $isVisible={true}>
             {Object.entries(totalCategories).map(([key, category]) => (
                 <StyledButton
                     key={key}
@@ -74,9 +74,12 @@ const SearchChipsWrapper = styled.div<{ $isVisible: boolean }>`
     -webkit-overflow-scrolling: touch;
 
     // 사라지는 모션
-    opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
-    max-height: ${({ $isVisible }) =>
-        $isVisible ? "92px" : "0px"}; /* 배너 높이 지정 */
+    /* opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
+    max-height: ${({ $isVisible }) => ($isVisible ? "92px" : "0px")}; =
+    transition: opacity 0.5s ease-in-out, max-height 0.5s ease-in-out;
+    */
+    opacity: 1;
+    max-height: 92px;
     transition: opacity 0.5s ease-in-out, max-height 0.5s ease-in-out;
 
     /* 전체 스크롤바 크기 조정 */

--- a/src/hooks/queries/prompts/usePromptsListQuery.tsx
+++ b/src/hooks/queries/prompts/usePromptsListQuery.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
 import { getPromptsList } from "@/apis/prompt/prompt";
 import {
     GetPromptsListResponse,
@@ -9,6 +7,8 @@ import {
     ViewType,
 } from "@/apis/prompt/prompt.model";
 import { PROMPT_KEYS } from "@/hooks/queries/QueryKeys";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 
 export interface PromptQueryProps {
     sortBy: SortType;
@@ -37,7 +37,7 @@ const usePromptsListQuery = ({
         ...(categories !== undefined && { categories }),
     });
 
-    const { data, isLoading } = useQuery<GetPromptsListResponse>({
+    const { data, isLoading, refetch } = useQuery<GetPromptsListResponse>({
         queryKey: queryKey,
         queryFn: () =>
             getPromptsList({
@@ -49,9 +49,9 @@ const usePromptsListQuery = ({
                 query: query,
                 categories: categories,
             }).then((res) => res),
-        staleTime: 1000 * 60 * 5,
+        staleTime: 0,
+        refetchOnMount: "always",
     });
-
     const handlePageChange = (page: number) => {
         setCurrentPage(page);
     };
@@ -67,6 +67,7 @@ const usePromptsListQuery = ({
         currentPage,
         itemsPerPage,
         handlePageChange,
+        refetch,
     };
 };
 

--- a/src/states/searchState.ts
+++ b/src/states/searchState.ts
@@ -1,22 +1,16 @@
 import { atom } from "recoil";
-import { recoilPersist } from "recoil-persist";
-
-const { persistAtom } = recoilPersist();
 
 export const keywordState = atom({
     key: "keywordState",
     default: "",
-    effects_UNSTABLE: [persistAtom],
 });
 
 export const searchedKeywordState = atom({
     key: "searchedKeywordState",
     default: "",
-    effects_UNSTABLE: [persistAtom],
 });
 
 export const searchedCategoryState = atom({
     key: "searchedCategoryState",
     default: "total",
-    effects_UNSTABLE: [persistAtom],
 });


### PR DESCRIPTION

## 🏆 Details

- 프롬프트 상세 페이지 들어갔다가 뒤로가기 했을 때 검색유지
- 프롬프트 상세가 아닌 다른 페이지, 홈 로고 클릭했을 때, 새로고침 했을 때 검색 초기화

 (현재 next 14버전을 사용하면서 상위 레이아웃이 공유되어 있는 구조가 잘못된 듯 합니다.)
 (최대한 구조 변경없이 수정해보았습니다. 다른 사이드 이펙트가 나오면 공유 부탁드립니다!)
