### PR TITLE
fix : 경로 리다이렉트

### DIFF
--- a/src/app/prompt/[promptType]/[promptId]/page.tsx
+++ b/src/app/prompt/[promptType]/[promptId]/page.tsx
@@ -1,19 +1,17 @@
+// "/prompt/{type}/{id}"
 import PromptContent from "@/components/prompt/PromptContent";
 import { prefetchPrompt } from "@/hooks/prefetches/usePrefetchPrompt";
 
-export interface PromptPageProps {
+interface PromptPageProps {
     params: {
         promptType: "text" | "image";
         promptId: string;
     };
 }
 
-const PromptPage = async ({ params }: PromptPageProps) => {
+export default async function PromptPage({ params }: PromptPageProps) {
     const { promptType, promptId } = params;
-
     await prefetchPrompt(promptType, promptId);
 
     return <PromptContent promptType={promptType} promptId={promptId} />;
-};
-
-export default PromptPage;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,42 @@
+// src/middleware.ts
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export const config = {
+    matcher: ["/prompt/:promptId*"],
+};
+
+export async function middleware(req: NextRequest) {
+    console.log("DEBUG [middleware]: Triggered for:", req.nextUrl.pathname);
+
+    const match = req.nextUrl.pathname.match(/^\/prompt\/([a-f0-9]{24})$/);
+    if (!match) return NextResponse.next();
+    const promptId = match[1];
+
+    try {
+        const apiUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/prompts/${promptId}`;
+        console.log("DEBUG [middleware]: API URL:", apiUrl);
+
+        const apiRes = await fetch(apiUrl, { cache: "no-store" });
+        if (!apiRes.ok) {
+            console.log("DEBUG [middleware]: API failed:", apiRes.status);
+            return NextResponse.rewrite(new URL("/404", req.url));
+        }
+
+        const json = await apiRes.json();
+        console.log("DEBUG [middleware]: Fetched raw JSON:", json);
+        const type = json.type ?? json.data?.type;
+        console.log("DEBUG [middleware]: Resolved type:", type);
+
+        if (type !== "text" && type !== "image") {
+            return NextResponse.rewrite(new URL("/404", req.url));
+        }
+
+        const redirectUrl = new URL(`/prompt/${type}/${promptId}`, req.url);
+        console.log("DEBUG [middleware]: Redirecting to:", redirectUrl);
+        return NextResponse.redirect(redirectUrl);
+    } catch (e) {
+        console.error("DEBUG [middleware]: Error during fetch:", e);
+        return NextResponse.rewrite(new URL("/404", req.url));
+    }
+}


### PR DESCRIPTION
## 🏆 Details

-   src/middleware.ts 추가 
-  응답의 `type`(text | image) 값에 따라 `/prompt/{type}/{id}` 로 307 Redirect
- ID가 유효하지 않으면 404 페이지로 리라이트

### 검증
1. `GET /prompt` → `/prompt/text`  
2. `GET /prompt/{24hexID}` → middleware → `/prompt/{type}/{id}`  
3. `/prompt/text/...`, `/prompt/image/...` → 기존 컴포넌트 정상 렌더링

