### PR TITLE
refactor: update useSearch hook to manage searchedKeyword state and i…

### DIFF
--- a/src/hooks/queries/useSearch.tsx
+++ b/src/hooks/queries/useSearch.tsx
@@ -10,7 +10,7 @@ import { sortTypeState } from "@/states/sortState";
 import { useDeviceSize } from "@components/DeviceContext";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 
 export const useSearch = (promptType: "text" | "image") => {
     const { isUnderTablet } = useDeviceSize();
@@ -22,7 +22,8 @@ export const useSearch = (promptType: "text" | "image") => {
     const [searchedCategory, setSearchedCategory] = useRecoilState(
         searchedCategoryState
     );
-    const setSearchedKeyword = useSetRecoilState(searchedKeywordState);
+    const [searchedKeyword, setSearchedKeyword] =
+        useRecoilState(searchedKeywordState);
     const sortBy = useRecoilValue(sortTypeState);
 
     // Local
@@ -139,6 +140,7 @@ export const useSearch = (promptType: "text" | "image") => {
     };
 
     return {
+        keyword: searchedKeyword,
         searchedCategory,
         searchResults,
         handleSearch,


### PR DESCRIPTION
## 🐛 Fix: SearchSection 컴포넌트의 keyword 프로퍼티 타입 에러 수정

### 📝 문제 상황
- `SearchSection.tsx`에서 `useSearch` hook으로부터 `keyword` 프로퍼티에 접근 시 타입 에러 발생
- `useSearch` hook이 `keyword`를 반환하지 않아 빌드 실패

### 🔧 수정 내용
- `useSearch` hook에서 `searchedKeywordState`를 `useRecoilState`로 변경하여 키워드 값을 가져올 수 있도록 수정
- hook의 반환값에 `keyword: searchedKeyword` 추가
- 불필요한 `useSetRecoilState` import 제거

### 📂 수정된 파일
- `src/hooks/queries/useSearch.tsx`

### ✅ 테스트
- [x] 타입 체크 통과
- [x] 빌드 성공 (`yarn build:dev`)
- [x] SearchSection 컴포넌트에서 keyword 프로퍼티 정상 접근 가능

### 🔍 변경사항 세부내용
```typescript
// Before
const setSearchedKeyword = useSetRecoilState(searchedKeywordState);

return {
    searchedCategory,
    searchResults,
    // keyword 누락
};

// After  
const [searchedKeyword, setSearchedKeyword] = useRecoilState(searchedKeywordState);

return {
    keyword: searchedKeyword,
    searchedCategory,
    searchResults,
};
```

### 📌 관련 이슈
- 빌드 시 타입 에러로 인한 컴파일 실패 해결