### PR TITLE
fix: ensure edited AI titles are saved

### DIFF
--- a/src/components/promptNew/FormSecSection.tsx
+++ b/src/components/promptNew/FormSecSection.tsx
@@ -13,17 +13,10 @@ import FormItem from "./Form/FormItem";
 interface FormSectionProps {
     isEdit: boolean;
     promptTemplate: string;
-    setSelectedTitle: (selectedText: string) => void;
-    setSelectedDescription: (selectedText: string) => void;
     goToNextTab: () => void;
 }
 
-function FormSecSection({
-    isEdit,
-    goToNextTab,
-    setSelectedTitle,
-    setSelectedDescription,
-}: FormSectionProps) {
+function FormSecSection({ isEdit, goToNextTab, promptTemplate }: FormSectionProps) {
     const {
         control,
         setValue,
@@ -40,12 +33,10 @@ function FormSecSection({
         promptTitleValue.length > 0 && promptDescriptionValue.length > 0;
 
     const handleSelectTitle = (selectedText: string) => {
-        setSelectedTitle(selectedText);
         setValue("title", selectedText);
     };
 
     const handleSelectDescription = (selectedText: string) => {
-        setSelectedDescription(selectedText);
         setValue("description", selectedText);
     };
 

--- a/src/components/promptNew/index.tsx
+++ b/src/components/promptNew/index.tsx
@@ -68,10 +68,6 @@ export default function NewPromptClient({
     // LNB 탭으로 관리
     const [activeTab, setActiveTab] = useState("1");
     const [promptTemplate, setPromptTemplate] = useState("");
-    const [selectedTitle, setSelectedTitle] = useState<string | null>(null);
-    const [selectedDescription, setSelectedDescription] = useState<
-        string | null
-    >(null);
 
     const { isUnderTablet } = useDeviceSize();
     const [isClient, setIsClient] = useState(false);
@@ -140,8 +136,6 @@ export default function NewPromptClient({
             // 나머지 상태도 초기화
             setImageFileList([]);
             setSampleMediaUrls([]);
-            setSelectedTitle(null);
-            setSelectedDescription(null);
         }
 
         setIsChangeModalOpen(false);
@@ -358,8 +352,8 @@ export default function NewPromptClient({
                 const promptData: CreatePromptRequest = {
                     ...input,
                     type: typeMap[contentBy as keyof typeof typeMap],
-                    title: selectedTitle || input.title,
-                    description: selectedDescription || input.description,
+                    title: input.title,
+                    description: input.description,
                     visibility: input.visibility.toLowerCase(),
                     user_input_format: user_input_formats,
                     categories: input.categories || [],
@@ -626,8 +620,6 @@ export default function NewPromptClient({
                                 isEdit={isEdit}
                                 goToNextTab={goToNextTab}
                                 promptTemplate={promptTemplate}
-                                setSelectedTitle={setSelectedTitle}
-                                setSelectedDescription={setSelectedDescription}
                             />
                             {contentBy === "이미지 프롬프트" && (
                                 <ImgUploadSection


### PR DESCRIPTION
프롬프트 등록 화면 저장 불가 버그 수정

이슈:
- “AI helper”가 자동 생성한 프롬프트 제목·설명을 그대로 사용하도록 체크해 두면, 초안 편집 후 “등록”을 눌러도 수정 내용이 반영되지 않는 문제

해결:
- 이 로직을 수정해 사용자가 편집한 내용이 제대로 저장되도록 개선