### PR TITLE
Add sitemap generation for App Router

### DIFF
--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,0 +1,66 @@
+import { MetadataRoute } from "next";
+import { getPromptsList } from "@/apis/prompt/prompt";
+
+export const dynamic = "force-static";
+
+export async function GET(): Promise<MetadataRoute.Sitemap> {
+    if (process.env.APP_ENV !== "production") {
+      return [];
+    }
+
+    const baseUrl = process.env.NEXT_PUBLIC_WEB_URL ?? "https://www.pocket-prompt.com";
+
+    const [textPrompts, imagePrompts] = await Promise.all([
+      getPromptsList({
+        view_type: "open",
+        sort_by: "created_at",
+        sort_order: "desc",
+        limit: 1000,
+        page: 1,
+        prompt_type: "text",
+      }),
+      getPromptsList({
+        view_type: "open",
+        sort_by: "created_at",
+        sort_order: "desc",
+        limit: 1000,
+        page: 1,
+        prompt_type: "image",
+      }),
+    ]);
+
+    const latestTextCreated = textPrompts.prompt_info_list[0]?.created_at;
+    const latestImageCreated = imagePrompts.prompt_info_list[0]?.created_at;
+
+    const staticEntries: MetadataRoute.Sitemap = [
+      {
+        url: `${baseUrl}/prompt/text`,
+        lastModified: latestTextCreated,
+      },
+      {
+        url: `${baseUrl}/prompt/image`,
+        lastModified: latestImageCreated,
+      },
+      {
+        url: `${baseUrl}/extension`,
+        lastModified: "2025-06-29",
+      },
+      {
+        url: `${baseUrl}/price`,
+        lastModified: "2025-06-29",
+      },
+    ];
+
+    const dynamicEntries: MetadataRoute.Sitemap = [
+      ...textPrompts.prompt_info_list.map((prompt) => ({
+        url: `${baseUrl}/prompt/text/${prompt.id}`,
+        lastModified: prompt.created_at,
+      })),
+      ...imagePrompts.prompt_info_list.map((prompt) => ({
+        url: `${baseUrl}/prompt/image/${prompt.id}`,
+        lastModified: prompt.created_at,
+      })),
+    ];
+
+    return [...staticEntries, ...dynamicEntries];
+}


### PR DESCRIPTION
`src/app/sitemap.xml/route.ts`에 새로운 **`GET` 라우트**를 추가해 애플리케이션의 사이트맵을 **동적으로 생성**합니다. 덕분에 정적·동적 URL 모두 최신 프롬프트 기준으로 항상 업데이트된 상태를 유지합니다.

### 사이트맵 생성 내용

* **`MetadataRoute.Sitemap`** 타입을 이용해 사이트맵을 만드는 `GET` 메서드를 새로 구현했습니다.

  * 주요 페이지는 **정적 항목**으로,
  * `getPromptsList` API에서 가져온 개별 텍스트·이미지 프롬프트는 **동적 항목**으로 포함했습니다.
* 라우트를 **`force-static`** 설정으로 고정해 환경이 달라져도 동일하게 동작하도록 했으며, **프로덕션 환경이 아닐 때는 빈 사이트맵**을 반환하도록 조건을 추가했습니다.
