### PR TITLE
Add sitemap generator

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,76 @@
+import { MetadataRoute } from 'next'
+
+export const dynamic = 'force-static'
+
+const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://www.pocket-prompt.com'
+const API_BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || ''
+
+interface Prompt {
+    id: string
+    created_at: string
+}
+
+async function fetchPrompts(promptType: 'text' | 'image'): Promise<Prompt[]> {
+    const params = new URLSearchParams({
+        view_type: 'open',
+        prompt_type: promptType,
+        sort_by: 'created_at',
+        sort_order: 'desc',
+        limit: '1000',
+        page: '1',
+    })
+
+    const res = await fetch(`${API_BASE_URL}/prompts-list?${params.toString()}`)
+    if (!res.ok) {
+        console.error(`[sitemap] Failed to fetch prompts: ${res.status}`)
+        return []
+    }
+    const json = await res.json()
+    const list = json?.data?.prompt_info_list ?? json?.prompt_info_list
+    return Array.isArray(list) ? list : []
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+    if (process.env.APP_ENV !== 'production') {
+        return []
+    }
+
+    try {
+        const [textPrompts, imagePrompts] = await Promise.all([
+            fetchPrompts('text'),
+            fetchPrompts('image'),
+        ])
+
+        const routes: MetadataRoute.Sitemap = [
+            {
+                url: `${WEB_URL}/prompt/text`,
+                lastModified: textPrompts[0] ? new Date(textPrompts[0].created_at) : undefined,
+            },
+            {
+                url: `${WEB_URL}/prompt/image`,
+                lastModified: imagePrompts[0] ? new Date(imagePrompts[0].created_at) : undefined,
+            },
+            {
+                url: `${WEB_URL}/extension`,
+                lastModified: new Date('2025-06-29'),
+            },
+            {
+                url: `${WEB_URL}/price`,
+                lastModified: new Date('2025-06-29'),
+            },
+            ...textPrompts.map((p) => ({
+                url: `${WEB_URL}/prompt/text/${p.id}`,
+                lastModified: new Date(p.created_at),
+            })),
+            ...imagePrompts.map((p) => ({
+                url: `${WEB_URL}/prompt/image/${p.id}`,
+                lastModified: new Date(p.created_at),
+            })),
+        ]
+
+        return routes
+    } catch (e) {
+        console.error('[sitemap] Unexpected error generating sitemap', e)
+        return []
+    }
+}


### PR DESCRIPTION
Prompt
```
Next JS에서 app/sitemap.ts에 사이트맵을 만들어줘.
prompt는 각 1000개

정적 (lastModified)
https://www.pocket-prompt.com/prompt/text (텍스트 프롬프트의 가장 최근 created 날짜)
https://www.pocket-prompt.com/prompt/image (이미지 프롬프트의 가장 최근 created 날짜)
https://www.pocket-prompt.com/extension (2025-06-29)
https://www.pocket-prompt.com/price (2025-06-29)

동적
https://www.pocket-prompt.com/prompt/text/{promptId}
https://www.pocket-prompt.com/prompt/image/{promptId}

- APP_ENV=production일때만
- export const dynamic = 'force-static'로 처음 한 번만 갱신
- lastModified는 prompt.created_at를 참고해

import { MetadataRoute } from 'next'
 
export default function sitemap(): MetadataRoute.Sitemap {
```

Note:
- https://nextjs.org/docs/14/app/api-reference/file-conventions/metadata/sitemap 참고했습니다

## Summary
- generate sitemap under `src/app/sitemap.ts`

## Testing
- `yarn lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6860c1a63e208321ba2197ebe60735c5