### PR TITLE
Update robots rules

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,24 @@
+import { MetadataRoute } from 'next'
+
+export const dynamic = 'force-static'
+
+const WEB_URL = process.env.NEXT_PUBLIC_WEB_URL || 'https://www.pocket-prompt.com'
+
+export default function robots(): MetadataRoute.Robots {
+    if (process.env.APP_ENV !== 'production') {
+        return {
+            rules: {
+                userAgent: '*',
+                disallow: '/',
+            },
+        }
+    }
+
+    return {
+        rules: {
+            userAgent: '*',
+            allow: '/',
+        },
+        sitemap: `${WEB_URL}/sitemap.xml`,
+    }
+}


### PR DESCRIPTION
## Prompt

SEO 친화적인 app/robots.ts 만들어줘.

- 환경이 production 말고 development일때는, User-agent: * Disallow: /로 전부 차단
- 아래 foramt으로

Generate a Robots file
Add a robots.js or robots.ts file that returns a Robots object.

app/robots.ts
 
TypeScript
``` 
import { MetadataRoute } from 'next'
 
export default function robots(): MetadataRoute.Robots {
  return {
    rules: {
      userAgent: '*',
      allow: '/',
      disallow: '/private/',
    },
    sitemap: 'https://acme.com/sitemap.xml',
  }
}
```

## Summary
- remove disallow rule from `src/app/robots.ts`

## Testing
- `npx eslint -c eslint.config.mjs "src/app/robots.ts"` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6860c73bbbdc83218c2e833c281d94cb