### PR TITLE
Fix share link copies clean URL

### DIFF
--- a/src/components/prompt/TopSection.tsx
+++ b/src/components/prompt/TopSection.tsx
@@ -9,7 +9,7 @@ import Text from "@/components/common/Text/Text";
 import { Categories, Category, ImageCategories } from "@/core/Prompt";
 import useToast from "@/hooks/useToast";
 import { useUser } from "@/hooks/useUser";
-import { copyClipboard } from "@/utils/promptUtils";
+import { copyClipboard, getShareUrl } from "@/utils/promptUtils";
 import { formatDate, formatNumber } from "@/utils/textUtils";
 import { useDeviceSize } from "@components/DeviceContext";
 import { Flex } from "antd";
@@ -30,7 +30,7 @@ export const TopSection = ({ prompt }: TopSectionProps) => {
     const { isMobile } = useDeviceSize();
 
     const handleShare = () => {
-        const url = window.location.href;
+        const url = getShareUrl(window.location.href);
         copyClipboard(url)
             .then(() => {
                 showToast({

--- a/src/utils/promptUtils.ts
+++ b/src/utils/promptUtils.ts
@@ -35,3 +35,17 @@ export function populateTemplate(
 export function copyClipboard(text: string) {
     return navigator.clipboard.writeText(text);
 }
+
+/**
+ * 현재 주소에서 쿼리 문자열과 해시를 제거한 주소를 반환하는 함수
+ * @param href 현재 url
+ * @returns 쿼리가 제거된 url
+ */
+export function getShareUrl(href: string): string {
+    try {
+        const url = new URL(href);
+        return `${url.origin}${url.pathname}`;
+    } catch {
+        return href;
+    }
+}

--- a/tests/getShareUrl.test.ts
+++ b/tests/getShareUrl.test.ts
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'assert';
+import { getShareUrl } from '../src/utils/promptUtils';
+
+test('removes query string and hash from url', () => {
+  const url = 'https://example.com/prompt/123?query=abc#hash';
+  const result = getShareUrl(url);
+  assert.strictEqual(result, 'https://example.com/prompt/123');
+});


### PR DESCRIPTION
## Summary
- ensure share button copies link without query string
- expose `getShareUrl` util
- add test for `getShareUrl`

## Testing
- `npx eslint src/utils/promptUtils.ts` *(fails: Cannot find package 'eslint-plugin-react-refresh')*

------
https://chatgpt.com/codex/tasks/task_e_6860cd5b22b88321bafcbb492a89e5ae