### PR TITLE
Add UTM parameters to prompt share link

### DIFF
--- a/src/components/prompt/TopSection.tsx
+++ b/src/components/prompt/TopSection.tsx
@@ -30,7 +30,8 @@ export const TopSection = ({ prompt }: TopSectionProps) => {
     const { isMobile } = useDeviceSize();
 
     const handleShare = () => {
-        const url = getShareUrl(window.location.href);
+        const baseUrl = getShareUrl(window.location.href);
+        const url = `${baseUrl}?utm_source=prompt_share_btn&utm_medium=share&utm_campaign=prompt_share&utm_term=${prompt.id}`;
         copyClipboard(url)
             .then(() => {
                 showToast({


### PR DESCRIPTION
## Summary
- append UTM parameters when copying prompt share URL so that button clicks can be tracked

## Testing
- `node --test`
- `npm run lint` *(fails: asks for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6860d1b32ffc8321abffb32ccb071a96