### PR TITLE
Fix search not updating on enter

### DIFF
--- a/src/hooks/queries/useSearch.tsx
+++ b/src/hooks/queries/useSearch.tsx
@@ -80,6 +80,8 @@ export const useSearch = (promptType: "text" | "image") => {
      * 2) 검색 실행 및 URL 업데이트
      */
     const handleSearch = (newKeyword: string, newCategory: string) => {
+        setSearchedKeyword(newKeyword);
+        setSearchedCategory(newCategory);
         const qp = new URLSearchParams();
         if (newKeyword) qp.set("keyword", newKeyword);
         if (newCategory && newCategory !== "total")


### PR DESCRIPTION
## Summary
- sync searched keyword and category when performing a search

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_6860f31d01dc8321b180dfdc5714fc66