### PR TITLE
Fix search input for IME usage

### DIFF
--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -25,7 +25,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             onChange(inputValue);
         };
 
+        // IME composition awareness
         const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.nativeEvent.isComposing) return;
             if (e.key === "Enter" && onEnter) {
                 onEnter();
             }


### PR DESCRIPTION
## Summary
- handle composition events in `Input` so `Enter` triggers search while using IME

## Testing
- `yarn lint` *(fails: needs setup)*
- `node --test tests/getShareUrl.test.ts` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_6862aaa056fc8321b199d47065aaa51b