### PR TITLE
Fix search update from home search bar

### DIFF
--- a/src/components/home/HomeContentBase.tsx
+++ b/src/components/home/HomeContentBase.tsx
@@ -38,7 +38,14 @@ export default function HomeContentBase({
 }: HomeContentBaseProps) {
     const [isVocModalOpen, setIsVocModalOpen] = useState(false);
     const promptData = usePromptData(promptType);
-    const { searchResults, isLoading, isInitialized } = useSearch(promptType);
+    const {
+        searchResults,
+        isLoading,
+        isInitialized,
+        handleSearch,
+        keyword,
+        searchedCategory,
+    } = useSearch(promptType);
     const { isUnderTablet } = useDeviceSize();
     const { userData } = useUser();
     const { data: userPaymentData } = useGetSubscription({
@@ -68,7 +75,12 @@ export default function HomeContentBase({
                 </LeftSection>
                 <ContentWrapper>
                     <Banner />
-                    <SearchSection promptType={promptType} />
+                    <SearchSection
+                        promptType={promptType}
+                        handleSearch={handleSearch}
+                        keyword={keyword}
+                        searchedCategory={searchedCategory}
+                    />
                     <PromptListSection
                         promptData={promptData}
                         searchResults={searchResults}

--- a/src/components/home/SearchSection.tsx
+++ b/src/components/home/SearchSection.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useSearch } from "@/hooks/queries/useSearch";
-import { useDeviceSize } from "@components/DeviceContext";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import SearchBar from "./searchUI/SearchBar";
@@ -9,18 +7,17 @@ import SearchChips from "./searchUI/SearchChips";
 
 interface SearchSectionProps {
     promptType: "text" | "image";
+    handleSearch: (keyword: string, category: string) => void;
+    keyword: string;
+    searchedCategory: string;
 }
 
-export default function SearchSection({ promptType }: SearchSectionProps) {
-    const { isUnderTablet } = useDeviceSize();
-    const {
-        keyword,
-        searchedCategory,
-        handleSearch,
-        searchResults,
-        isLoading,
-    } = useSearch(promptType);
-
+export default function SearchSection({
+    promptType,
+    handleSearch,
+    keyword,
+    searchedCategory,
+}: SearchSectionProps) {
     // 로컬 인풋 상태
     const [localKeyword, setLocalKeyword] = useState(keyword);
     useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure search results are shared across home page components
- pass search state from `HomeContentBase` to `SearchSection`
- remove unused imports

## Testing
- `yarn lint` *(fails: prompts interactive setup)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6862aaa056fc8321b199d47065aaa51b