### PR TITLE
fix: trigger search on Enter when using IME

### DIFF
--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -25,7 +25,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             onChange(inputValue);
         };
 
+        // IME composition awareness
         const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.nativeEvent.isComposing) return;
             if (e.key === "Enter" && onEnter) {
                 onEnter();
             }


### PR DESCRIPTION
This pull request introduces a small but important enhancement to the `Input` component in `src/components/common/Input/Input.tsx`. The change adds IME (Input Method Editor) composition awareness to the `handleKeyDown` function, ensuring that the `Enter` key behavior does not interfere with ongoing text composition.