### PR TITLE
fix: AI 추천 무한 실행 이슈 수정

### DIFF
--- a/src/components/promptNew/AiBox/AiRunBox.tsx
+++ b/src/components/promptNew/AiBox/AiRunBox.tsx
@@ -21,7 +21,7 @@ export const AiRunBox = ({
     onSelect,
 }: AiRunBoxProps) => {
     const [checked, setChecked] = useState<boolean>(false);
-    const [animationKey, setAnimationKey] = useState<number>(0);
+    const [animationKey, setAnimationKey] = useState<number>(1); // 초기값 1로 설정하여 처음 한 번 자동 실행
 
     const {
         data: suggestionData,

--- a/src/hooks/mutations/prompts/useGetAiSuggestions.tsx
+++ b/src/hooks/mutations/prompts/useGetAiSuggestions.tsx
@@ -42,11 +42,11 @@ export const useGetAiSuggestions = (
     return useQuery<{ title: string; description: string }>({
         queryKey: [
             "aiSuggestions",
-            promptTemplateValue,
             suggestionType,
             retryKey,
         ],
         queryFn: () => getAiSuggestion(promptTemplateValue),
-        enabled: !!promptTemplateValue, // promptTemplateValue가 있을 때만 요청
+        enabled: !!promptTemplateValue && retryKey > 0, // retryKey가 0보다 클 때만 요청 (명시적으로 트리거된 경우만)
+        staleTime: Infinity, // 캐시된 데이터를 항상 신선하게 유지 (자동 refetch 방지)
     });
 };


### PR DESCRIPTION
## 문제
프롬프트 생성/수정 시 AI 추천이 계속 실행되는 이슈

## 원인
- `useGetAiSuggestions`의 queryKey에 `promptTemplateValue`가 포함되어 있어 프롬프트 내용 타이핑 시마다 queryKey가 변경됨
- queryKey 변경 → React Query 자동 재실행 → API 무한 호출

## 수정 내용
### `useGetAiSuggestions.tsx`
- queryKey에서 `promptTemplateValue` 제거
- `enabled` 조건에 `retryKey > 0` 추가 (명시적 트리거만 허용)
- `staleTime: Infinity` 추가 (자동 refetch 방지)

### `AiRunBox.tsx`
- `animationKey` 초기값을 `0` → `1`로 변경 (처음 한 번 자동 실행)

## 동작 방식
- 컴포넌트 마운트 시 **한 번만** AI 추천 실행
- 프롬프트 내용 수정해도 **재실행 안 됨**
- "다시 생성하기" 버튼 클릭 시에만 **새로 실행**